### PR TITLE
Fix #25 and some more

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ NATS does not use the concept of partitions. The binder supports the API for par
 By default, properties are configured using the `nats.spring` prefix:
 
 * `nats.spring.server` specifies the NATS server url or a list of urls in a comma separated list
-* `nats.spring.connectionname` the connection name
-* `nats.spring.maxreconnect` the maximum reconnects attempts on a single disconnect before the connection closes
-* `nats.spring.reconnectwait` the time, as a duration like `4s`, to wait between trying to reconnect to the same server
-* `nats.spring.connectiontimeout` the time, as a duration like `4s`, to wait before cancelling the connection
-* `nats.spring.pinginterval` the time, as a duration like `4s`, between pings to the server
-* `nats.spring.reconnectbuffersize` the size in bytes for the reconnect buffer
-* `nats.spring.inboxprefix` a custom inbox prefix
-* `nats.spring.noecho` turn off echo from the server
-* `nats.spring.utf8support` enable UTF-8 subject names (warning this is an experimental feature, not all language clients will support it)
+* `nats.spring.connection-name` the connection name
+* `nats.spring.max-reconnect` the maximum reconnects attempts on a single disconnect before the connection closes
+* `nats.spring.reconnect-wait` the time, as a duration like `4s`, to wait between trying to reconnect to the same server
+* `nats.spring.connection-timeout` the time, as a duration like `4s`, to wait before cancelling the connection
+* `nats.spring.ping-interval` the time, as a duration like `4s`, between pings to the server
+* `nats.spring.reconnect-buffer-size` the size in bytes for the reconnect buffer
+* `nats.spring.inbox-prefix` a custom inbox prefix
+* `nats.spring.no-echo` turn off echo from the server
+* `nats.spring.utf8-support` enable UTF-8 subject names (warning this is an experimental feature, not all language clients will support it)
 * `nats.spring.username`, `nats.spring.password` the user name and password to authenticate with
 * `nats.spring.token` an authentication token, takes precedence over the username/password
 * `nats.spring.credentials` a path to a credentials file, takes precedence over the token and user/pass
@@ -176,14 +176,20 @@ By default, properties are configured using the `nats.spring` prefix:
 
 TLS can be configured several ways. Set up a default context using system properties like `javax.net.ssl.keyStore`, set a default SSLContext in the main method before running the spring application, or by setting several properties:
 
-* `nats.spring.keystorepath` the path to the key store file
-* `nats.spring.keystorepassword` the password for the key store, defaults to ""
-* `nats.spring.keystoretype` (optional) the format of the key store, defaults to "SunX509"
-* `nats.spring.truststorepath` the path to the trust store file
-* `nats.spring.truststorepassword` the password for the trust store, defaults to ""
-* `nats.spring.truststoretype` (optional) the format of the trust store, defaults to "SunX509"
+* `nats.spring.trust-store-password` the password for the trust store, defaults to ""
+* `nats.spring.trust-store-path` the path to the trust store file
+* `nats.spring.trust-store-provider` (optional) the format of the trust store, defaults to "SunX509". Common options are "SunX509", "PKIX".
+* `nats.spring.trust-store-type` (optional) the format of the trust store, defaults to "PKCS12". Common options are "PKCS12", "JKS", "JCEKS", "DKS".
 
-The keyStorePath and trustStorePath must be non-empty to trigger the creation of an SSL context.
+* `nats.spring.key-store-password` the password for the key store, defaults to ""
+* `nats.spring.key-store-path` the path to the key store file
+* `nats.spring.key-store-provider` (optional) the format of the key store, defaults to "SunX509". Common options are "SunX509", "PKIX".
+* `nats.spring.key-store-type` (optional) the format of the key store, defaults to "PKCS12". Common options are "PKCS12", "JKS", "JCEKS", "DKS".
+
+* `nats.spring.tls-protocol` (optional) the preferred protocol for TLS handshake. Common options: TLSv1.2 (default), TLSv1.3.
+
+
+The `key-store-path` and `trust-store-path` must be non-empty to trigger the creation of an SSL context.
 
 ### Custom Listeners <a name="listeners"></a>
 

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
@@ -30,14 +30,13 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+
 import io.nats.client.Nats;
 import io.nats.client.Options;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-
 @ConditionalOnClass({ Options.class })
 public class NatsConnectionProperties {
-
 	/**
 	 * URL for the nats server, can be a comma separated list.
 	 */
@@ -49,7 +48,8 @@ public class NatsConnectionProperties {
 	private String connectionName;
 
 	/**
-	 * Maximum reconnect attempts if a connection is lost, after the initial connection.
+	 * Maximum reconnect attempts if a connection is lost, after the initial
+	 * connection.
 	 */
 	private int maxReconnect = Options.DEFAULT_MAX_RECONNECT;
 
@@ -59,8 +59,8 @@ public class NatsConnectionProperties {
 	private Duration reconnectWait = Options.DEFAULT_RECONNECT_WAIT;
 
 	/**
-	 * Timeout for the initial connection, if this time is passed, the connection will fail
-	 * and no reconnect attempts are made.
+	 * Timeout for the initial connection, if this time is passed, the connection
+	 * will fail and no reconnect attempts are made.
 	 */
 	private Duration connectionTimeout = Options.DEFAULT_CONNECTION_TIMEOUT;
 
@@ -70,7 +70,8 @@ public class NatsConnectionProperties {
 	private Duration pingInterval = Options.DEFAULT_PING_INTERVAL;
 
 	/**
-	 * Size of the buffer, in bytes, used to hold outgoing messages during reconnect.
+	 * Size of the buffer, in bytes, used to hold outgoing messages during
+	 * reconnect.
 	 */
 	private long reconnectBufferSize = Options.DEFAULT_RECONNECT_BUF_SIZE;
 
@@ -81,7 +82,28 @@ public class NatsConnectionProperties {
 	private String inboxPrefix = Options.DEFAULT_INBOX_PREFIX;
 
 	/**
-	 * Whether or not the server will send messages sent from this connection back to the connection.
+	 * Default KeyStore format/type for KeyManager instances
+	 */
+	private final String defaultKeyStoreType = "PKCS12";
+
+	/**
+	 * Default KeyStore format/type for TrustManager instances
+	 */
+	private final String defaultTrustStoreType = "PKCS12";
+
+	/**
+	 * Default KeyStore Provider Algorithm for KeyManager instances
+	 */
+	private final String defaultKeyStoreProviderAlgorithm = "SunX509";
+
+	/**
+	 * Default KeyStore Provider Algorithm for TrustManager instances
+	 */
+	private final String defaultTrustStoreProviderAlgorithm = "SunX509";
+
+	/**
+	 * Whether or not the server will send messages sent from this connection back
+	 * to the connection.
 	 */
 	private boolean noEcho;
 
@@ -91,27 +113,32 @@ public class NatsConnectionProperties {
 	private boolean utf8Support;
 
 	/**
-	 * Authentication user name. Requires the password, but not the token, or credentials, or NKey.
+	 * Authentication user name. Requires the password, but not the token, or
+	 * credentials, or NKey.
 	 */
 	private String username;
 
 	/**
-	 * Authentication password. Requires the username, but not the token, or credentials, or NKey.
+	 * Authentication password. Requires the username, but not the token, or
+	 * credentials, or NKey.
 	 */
 	private String password;
 
 	/**
-	 * Authentication token, do not use with username/password, or credentials, or NKey.
+	 * Authentication token, do not use with username/password, or credentials, or
+	 * NKey.
 	 */
 	private String token;
 
 	/**
-	 * User credentials file path, do not use with user/password, or token, or NKey. Credentials are used by account enabled servers.
+	 * User credentials file path, do not use with user/password, or token, or NKey.
+	 * Credentials are used by account enabled servers.
 	 */
 	private String credentials;
 
 	/**
-	 * Private key (seed) for NKey authentication, do not use with user/password, or token, or credentials.
+	 * Private key (seed) for NKey authentication, do not use with user/password, or
+	 * token, or credentials.
 	 */
 	private String nkey;
 
@@ -139,6 +166,21 @@ public class NatsConnectionProperties {
 	 * Password for the SSL trust store used to verify the server.
 	 */
 	private char[] trustStorePassword;
+
+	/**
+	 * Provider Algorithm for the the SSL key store, for verifying the server.
+	 */
+	private String keyStoreProvider;
+
+	/**
+	 * Provider Algorithm for the SSL trust store used to verify the server.
+	 */
+	private String trustStoreProvider;
+
+	/**
+	 * TLS Protocol version for the SSL Context Values: TLSv1.2, TLSv1.3
+	 */
+	private String tlsProtocol;
 
 	/**
 	 * Type of SSL trust store, generally the default is used.
@@ -198,7 +240,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param reconnectWait time to wait between reconnect attempts on the same server url
+	 * @param reconnectWait time to wait between reconnect attempts on the same
+	 *                      server url
 	 */
 	public void setReconnectWait(Duration reconnectWait) {
 		this.reconnectWait = reconnectWait;
@@ -233,14 +276,16 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @return size of the buffer, in bytes, used to store publish messages during reconnect
+	 * @return size of the buffer, in bytes, used to store publish messages during
+	 *         reconnect
 	 */
 	public long getReconnectBufferSize() {
 		return this.reconnectBufferSize;
 	}
 
 	/**
-	 * @param reconnectBufferSize size of the buffer, in bytes, used to store publish messages during reconnect
+	 * @param reconnectBufferSize size of the buffer, in bytes, used to store
+	 *                            publish messages during reconnect
 	 */
 	public void setReconnectBufferSize(long reconnectBufferSize) {
 		this.reconnectBufferSize = reconnectBufferSize;
@@ -309,7 +354,6 @@ public class NatsConnectionProperties {
 		return this.inboxPrefix;
 	}
 
-
 	/**
 	 * @param inboxPrefix custom prefix to use for request/reply inboxes
 	 */
@@ -318,21 +362,24 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @return whether or not to block echo messages, messages that were sent by this connection
+	 * @return whether or not to block echo messages, messages that were sent by
+	 *         this connection
 	 */
 	public boolean isNoEcho() {
 		return this.noEcho;
 	}
 
 	/**
-	 * @return whether or not to block echo messages, messages that were sent by this connection
+	 * @return whether or not to block echo messages, messages that were sent by
+	 *         this connection
 	 */
 	public boolean getNoEcho() {
 		return this.noEcho;
 	}
 
 	/**
-	 * @param noEcho enable or disable echo messages, messages that are sent by this connection back to this connection
+	 * @param noEcho enable or disable echo messages, messages that are sent by this
+	 *               connection back to this connection
 	 */
 	public void setNoEcho(boolean noEcho) {
 		this.noEcho = noEcho;
@@ -353,21 +400,24 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param utf8Support whether or not the client should support for UTF8 subject names
+	 * @param utf8Support whether or not the client should support for UTF8 subject
+	 *                    names
 	 */
 	public void setUtf8Support(boolean utf8Support) {
 		this.utf8Support = utf8Support;
 	}
 
 	/**
-	 * @return path to the credentials file to use for authentication with an account enabled server
+	 * @return path to the credentials file to use for authentication with an
+	 *         account enabled server
 	 */
 	public String getCredentials() {
 		return this.credentials;
 	}
 
 	/**
-	 * @param credentials path to the credentials file to use for authentication with an account enabled server
+	 * @param credentials path to the credentials file to use for authentication
+	 *                    with an account enabled server
 	 */
 	public void setCredentials(String credentials) {
 		this.credentials = credentials;
@@ -409,7 +459,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param keyStoreType generally the default, but available for special keystore formats/types
+	 * @param keyStoreType generally the default, but available for special keystore
+	 *                     formats/types
 	 */
 	public void setKeyStoreType(String keyStoreType) {
 		this.keyStoreType = keyStoreType;
@@ -451,14 +502,59 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param trustStoreType generally the default, but available for special trust store formats/types
+	 * @param trustStoreType generally the default, but available for special trust
+	 *                       store formats/types
 	 */
 	public void setTrustStoreType(String trustStoreType) {
 		this.trustStoreType = trustStoreType;
 	}
 
 	/**
-	 * @param serverURL used for the underlying nats connection, can be a comma separated list
+	 * @return keyStoreProvider of keystore to use for SSL connections
+	 */
+	public String getKeyStoreProvider() {
+		return keyStoreProvider;
+	}
+
+	/**
+	 * @param keyStoreProvider defaults to SunX509. Alternatives include PKIX.
+	 */
+	public void setKeyStoreProvider(String keyStoreProvider) {
+		this.keyStoreProvider = keyStoreProvider;
+	}
+
+	/**
+	 * @return trustStoreProvider of keystore to use for SSL connections
+	 */
+	public String getTrustStoreProvider() {
+		return trustStoreProvider;
+	}
+
+	/**
+	 * @param trustStoreProvider defaults to SunX509. Alternatives include PKIX.
+	 */
+	public void setTrustStoreProvider(String trustStoreProvider) {
+		this.trustStoreProvider = trustStoreProvider;
+	}
+
+	/**
+	 * 
+	 * @return tlsProtocol to be used in TLS handshake
+	 */
+	public String getTlsProtocol() {
+		return tlsProtocol;
+	}
+
+	/**
+	 * @param trustStoreProvider defaults to TLSv1.2
+	 */
+	public void setTlsProtocol(String tlsProtocol) {
+		this.tlsProtocol = tlsProtocol;
+	}
+
+	/**
+	 * @param serverURL used for the underlying nats connection, can be a comma
+	 *                  separated list
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties server(String serverURL) {
@@ -476,7 +572,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param maxReconnect limit on the number of reconnect attempts to make, per disconnect
+	 * @param maxReconnect limit on the number of reconnect attempts to make, per
+	 *                     disconnect
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties maxReconnect(int maxReconnect) {
@@ -485,7 +582,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param reconnectWait time to wait between reconnect attempts to the same server url
+	 * @param reconnectWait time to wait between reconnect attempts to the same
+	 *                      server url
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties reconnectWait(Duration reconnectWait) {
@@ -512,7 +610,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param reconnectBufferSize size, in bytes, of the buffer used to store outgoing messages during reconnect
+	 * @param reconnectBufferSize size, in bytes, of the buffer used to store
+	 *                            outgoing messages during reconnect
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties reconnectBufferSize(long reconnectBufferSize) {
@@ -566,7 +665,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param noEcho whether or not to send messages published by this connection back to it's subscribers
+	 * @param noEcho whether or not to send messages published by this connection
+	 *               back to it's subscribers
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties noEcho(boolean noEcho) {
@@ -584,7 +684,8 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param credentials file path to the user credentials to use for authentication
+	 * @param credentials file path to the user credentials to use for
+	 *                    authentication
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties credentials(String credentials) {
@@ -593,7 +694,7 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param keyStorePath file path to ssl keystore
+	 * @param keyStorePath file path to SSL Key Store
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties keyStorePath(String keyStorePath) {
@@ -602,7 +703,7 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param keyStorePassword required to unlock the ssl keystore
+	 * @param keyStorePassword required to unlock the SSL Key Store
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties keyStorePassword(char[] keyStorePassword) {
@@ -611,16 +712,7 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param keyStoreType type/format of the ssl keystore
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties keyStoreType(String keyStoreType) {
-		this.keyStoreType = keyStoreType;
-		return this;
-	}
-
-	/**
-	 * @param trustStorePath file path to ssl truststore
+	 * @param trustStorePath file path to SSL Trust Store
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties trustStorePath(String trustStorePath) {
@@ -629,16 +721,34 @@ public class NatsConnectionProperties {
 	}
 
 	/**
-	 * @param trustStorePassword required to unlock the ssl keystore
+	 * @param trustStorePassword required to unlock the SSL Trust Store
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties trustStorePassword(char[] trustStorePassword) {
-		this.trustStorePassword = trustStorePassword;
+		setTrustStorePassword(trustStorePassword);
 		return this;
 	}
 
 	/**
-	 * @param trustStoreType type/format of the ssl trust store
+	 * @param keyStoreType type/format of the SSL Key Store
+	 * @return chainable properties
+	 */
+	public NatsConnectionProperties keyStoreType(String keyStoreType) {
+		this.keyStoreType = keyStoreType;
+		return this;
+	}
+
+	/**
+	 * @param keyStoreProvider of the SSL Key Store
+	 * @return chainable properties
+	 */
+	public NatsConnectionProperties keyStoreProvider(String keyStoreProvider) {
+		this.keyStoreProvider = keyStoreProvider;
+		return this;
+	}
+
+	/**
+	 * @param trustStoreType type/format of the SSL Trust Store
 	 * @return chainable properties
 	 */
 	public NatsConnectionProperties trustStoreType(String trustStoreType) {
@@ -646,8 +756,27 @@ public class NatsConnectionProperties {
 		return this;
 	}
 
-	protected KeyStore loadKeystore(String path, char[] password) throws IOException, GeneralSecurityException {
-		KeyStore store = KeyStore.getInstance("JKS");
+	/**
+	 * @param trustStoreProvider of the SSL Trust Store
+	 * @return chainable properties
+	 */
+	public NatsConnectionProperties trustStoreProvider(String trustStoreProvider) {
+		this.trustStoreProvider = trustStoreProvider;
+		return this;
+	}
+
+	/**
+	 * @param trustStoreProvider of the SSL Trust Store
+	 * @return chainable properties
+	 */
+	public NatsConnectionProperties tlsProtocol(String tlsProtocol) {
+		this.tlsProtocol = tlsProtocol;
+		return this;
+	}
+
+	protected KeyStore loadKeystore(String path, char[] password, String keyStoreType)
+			throws IOException, GeneralSecurityException {
+		KeyStore store = KeyStore.getInstance(keyStoreType);
 
 		try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(path))) {
 			store.load(in, password);
@@ -656,58 +785,95 @@ public class NatsConnectionProperties {
 		return store;
 	}
 
-	protected KeyManager[] createKeyManagers(String path, char[] password, String type) throws IOException, GeneralSecurityException {
-		if (type == null || type.length() == 0) {
-			type = "SunX509";
+	protected KeyManager[] createKeyManagers(String path, char[] password, String keyStoreProvider, String keyStoreType)
+			throws IOException, GeneralSecurityException {
+		if (keyStoreProvider == null || keyStoreProvider.length() == 0) {
+			keyStoreProvider = defaultKeyStoreProviderAlgorithm;
+		}
+
+		if (keyStoreType == null || keyStoreType.length() == 0) {
+			keyStoreType = defaultKeyStoreType;
 		}
 
 		if (password == null || password.length == 0) {
 			password = new char[0];
 		}
 
-		KeyStore store = this.loadKeystore(path, password);
-		KeyManagerFactory factory = KeyManagerFactory.getInstance(type);
+		KeyStore store = this.loadKeystore(path, password, keyStoreType);
+		KeyManagerFactory factory = KeyManagerFactory.getInstance(keyStoreProvider);
 		factory.init(store, password);
 		return factory.getKeyManagers();
 	}
 
-	protected TrustManager[] createTrustManagers(String path, char[] password, String type) throws IOException, GeneralSecurityException {
-		if (type == null || type.length() == 0) {
-			type = "SunX509";
+	protected TrustManager[] createTrustManagers(String path, char[] password, String trustStoreProvider,
+			String trustStoreType) throws IOException, GeneralSecurityException {
+		if (trustStoreProvider == null || trustStoreProvider.length() == 0) {
+			trustStoreProvider = defaultTrustStoreProviderAlgorithm;
+		}
+
+		if (trustStoreType == null || trustStoreType.length() == 0) {
+			trustStoreType = defaultTrustStoreType;
 		}
 
 		if (password == null || password.length == 0) {
 			password = new char[0];
 		}
 
-		KeyStore store = loadKeystore(path, password);
-		TrustManagerFactory factory = TrustManagerFactory.getInstance(type);
-		factory.init(store);
+		KeyStore store = loadKeystore(path, password, trustStoreType);
+		TrustManagerFactory factory = TrustManagerFactory.getInstance(trustStoreProvider);
+		
+		/* 
+		 * Trust Store doesn't need to load any keys from the store (just certs)
+		 * so passing a password is not necessary
+		 */
+		factory.init(store); 
+		
 		return factory.getTrustManagers();
 	}
 
-	protected SSLContext createSSLContext() throws IOException, GeneralSecurityException  {
-		SSLContext ctx = SSLContext.getInstance(Options.DEFAULT_SSL_PROTOCOL);
-		ctx.init(this.createKeyManagers(this.keyStorePath, this.keyStorePassword, this.keyStoreType),
-					this.createTrustManagers(this.trustStorePath, this.trustStorePassword, this.trustStoreType), new SecureRandom());
+	/**
+	 * Create a SSLContext with the given tlsProtocol
+	 * 
+	 * @return SSLContext
+	 * @throws IOException
+	 * @throws GeneralSecurityException
+	 */
+	protected SSLContext createSSLContext() throws IOException, GeneralSecurityException {
+		
+		if (this.tlsProtocol == null || this.tlsProtocol.length() == 0) {
+			this.tlsProtocol = Options.DEFAULT_SSL_PROTOCOL;
+		}
+
+		SSLContext ctx = SSLContext.getInstance(this.tlsProtocol);
+		ctx.init(
+				this.createKeyManagers(this.keyStorePath, this.keyStorePassword, this.keyStoreProvider,
+						this.keyStoreType),
+				this.createTrustManagers(this.trustStorePath, this.trustStorePassword, this.trustStoreProvider,
+						this.trustStoreType),
+				new SecureRandom());
 		return ctx;
 	}
 
 	/**
 	 * @return NATS options based on this set of properties
-	 * @throws IOException if there is a problem reading a file or setting up the SSL context
-	 * @throws GeneralSecurityException if there is a problem setting up the SSL context
+	 * @throws IOException              if there is a problem reading a file or
+	 *                                  setting up the SSL context
+	 * @throws GeneralSecurityException if there is a problem setting up the SSL
+	 *                                  context
 	 */
-	public Options toOptions()  throws IOException, GeneralSecurityException  {
+	public Options toOptions() throws IOException, GeneralSecurityException {
 		return toOptionsBuilder().build();
 	}
 
 	/**
-	 * @return NATS options builder based on this set of properties, useful if other settings are required before connect is called
-	 * @throws IOException if there is a problem reading a file or setting up the SSL context
-	 * @throws GeneralSecurityException if there is a problem setting up the SSL context
+	 * @return NATS options builder based on this set of properties, useful if other
+	 *         settings are required before connect is called
+	 * @throws IOException              if there is a problem reading a file or
+	 *                                  setting up the SSL context
+	 * @throws GeneralSecurityException if there is a problem setting up the SSL
+	 *                                  context
 	 */
-	public Options.Builder toOptionsBuilder()  throws IOException, GeneralSecurityException  {
+	public Options.Builder toOptionsBuilder() throws IOException, GeneralSecurityException {
 		Options.Builder builder = new Options.Builder();
 
 		builder = builder.server(this.server);
@@ -729,19 +895,16 @@ public class NatsConnectionProperties {
 
 		if (this.nkey != null && this.nkey.length() > 0) {
 			builder = builder.authHandler(Nats.staticCredentials(null, this.nkey.toCharArray()));
-		}
-		else if (this.credentials != null && this.credentials.length() > 0) {
+		} else if (this.credentials != null && this.credentials.length() > 0) {
 			builder = builder.authHandler(Nats.credentials(this.credentials));
-		}
-		else if (this.token != null && this.token.length() > 0) {
-			builder = builder.token(this.token);
-		}
-		else if (this.username != null && this.username.length() > 0) {
-			builder = builder.userInfo(this.username, this.password);
+		} else if (this.token != null && this.token.length() > 0) {
+			builder = builder.token(this.token.toCharArray());
+		} else if (this.username != null && this.username.length() > 0) {
+			builder = builder.userInfo(this.username.toCharArray(), this.password.toCharArray());
 		}
 
-		if (this.keyStorePath != null && this.keyStorePath.length() > 0 &&
-			this.trustStorePath != null && this.trustStorePath.length() > 0) {
+		if (this.keyStorePath != null && this.keyStorePath.length() > 0 && this.trustStorePath != null
+				&& this.trustStorePath.length() > 0) {
 			builder.sslContext(this.createSSLContext());
 		}
 
@@ -750,21 +913,13 @@ public class NatsConnectionProperties {
 
 	@Override
 	public String toString() {
-		return "{" +
-		" server='" + getServer() + "'," +
-		" name='" + getConnectionName() + "'," +
-		" maxReconnect='" + getMaxReconnect() + "'," +
-		" reconnectWait='" + getReconnectWait() + "'," +
-		" connectionTimeout='" + getConnectionTimeout() + "'," +
-		" pingInterval='" + getPingInterval() + "'," +
-		" reconnectBufferSize='" + getReconnectBufferSize() + "'," +
-		" noEcho='" + getNoEcho() + "'," +
-		" utf8='" + getUtf8Support() + "'," +
-		" user='" + getUsername() + "'," +
-		" password='" + getPassword() + "'," +
-		" token='" + getToken() + "'," +
-		" creds='" + getCredentials() + "'," +
-		" nkey='" + getNkey() + "'," +
-			"}";
+		return "{" + " server='" + getServer() + "'," + " name='" + getConnectionName() + "'," + " maxReconnect='"
+				+ getMaxReconnect() + "'," + " reconnectWait='" + getReconnectWait() + "'," + " connectionTimeout='"
+				+ getConnectionTimeout() + "'," + " pingInterval='" + getPingInterval() + "',"
+				+ " reconnectBufferSize='" + getReconnectBufferSize() + "'," + " noEcho='" + getNoEcho() + "',"
+				+ " utf8='" + getUtf8Support() + "'," + " user='" + getUsername() + "'," + " password='" + getPassword()
+				+ "'," + " token='" + getToken() + "'," + " creds='" + getCredentials() + "'," + " nkey='" + getNkey()
+				+ "'," + "}";
 	}
+
 }

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
@@ -37,889 +37,911 @@ import io.nats.client.Options;
 
 @ConditionalOnClass({ Options.class })
 public class NatsConnectionProperties {
-	/**
-	 * URL for the nats server, can be a comma separated list.
-	 */
-	private String server;
-
-	/**
-	 * Connection name, shows up in thread names.
-	 */
-	private String connectionName;
-
-	/**
-	 * Maximum reconnect attempts if a connection is lost, after the initial
-	 * connection.
-	 */
-	private int maxReconnect = Options.DEFAULT_MAX_RECONNECT;
-
-	/**
-	 * Time to wait between reconnect attempts to the same server url.
-	 */
-	private Duration reconnectWait = Options.DEFAULT_RECONNECT_WAIT;
-
-	/**
-	 * Timeout for the initial connection, if this time is passed, the connection
-	 * will fail and no reconnect attempts are made.
-	 */
-	private Duration connectionTimeout = Options.DEFAULT_CONNECTION_TIMEOUT;
-
-	/**
-	 * Time between pings to the server to check "liveness".
-	 */
-	private Duration pingInterval = Options.DEFAULT_PING_INTERVAL;
-
-	/**
-	 * Size of the buffer, in bytes, used to hold outgoing messages during
-	 * reconnect.
-	 */
-	private long reconnectBufferSize = Options.DEFAULT_RECONNECT_BUF_SIZE;
-
-	/**
-	 * Prefix to use for inboxes, generally the default is used but custom prefixes
-	 * can allow security controls.
-	 */
-	private String inboxPrefix = Options.DEFAULT_INBOX_PREFIX;
-
-	/**
-	 * Default KeyStore format/type for KeyManager instances
-	 */
-	private final String defaultKeyStoreType = "PKCS12";
-
-	/**
-	 * Default KeyStore format/type for TrustManager instances
-	 */
-	private final String defaultTrustStoreType = "PKCS12";
-
-	/**
-	 * Default KeyStore Provider Algorithm for KeyManager instances
-	 */
-	private final String defaultKeyStoreProviderAlgorithm = "SunX509";
-
-	/**
-	 * Default KeyStore Provider Algorithm for TrustManager instances
-	 */
-	private final String defaultTrustStoreProviderAlgorithm = "SunX509";
-
-	/**
-	 * Whether or not the server will send messages sent from this connection back
-	 * to the connection.
-	 */
-	private boolean noEcho;
-
-	/**
-	 * Whether or not to treat subjects as UTF-8, the default is ASCII.
-	 */
-	private boolean utf8Support;
-
-	/**
-	 * Authentication user name. Requires the password, but not the token, or
-	 * credentials, or NKey.
-	 */
-	private String username;
-
-	/**
-	 * Authentication password. Requires the username, but not the token, or
-	 * credentials, or NKey.
-	 */
-	private String password;
-
-	/**
-	 * Authentication token, do not use with username/password, or credentials, or
-	 * NKey.
-	 */
-	private String token;
-
-	/**
-	 * User credentials file path, do not use with user/password, or token, or NKey.
-	 * Credentials are used by account enabled servers.
-	 */
-	private String credentials;
-
-	/**
-	 * Private key (seed) for NKey authentication, do not use with user/password, or
-	 * token, or credentials.
-	 */
-	private String nkey;
-
-	/**
-	 * Path to the SSL keystore.
-	 */
-	private String keyStorePath;
-
-	/**
-	 * Password for the SSL keystore.
-	 */
-	private char[] keyStorePassword;
-
-	/**
-	 * Type of SSL keystore, generally the default is used.
-	 */
-	private String keyStoreType;
-
-	/**
-	 * Path the the SSL trust store, for verifying the server.
-	 */
-	private String trustStorePath;
-
-	/**
-	 * Password for the SSL trust store used to verify the server.
-	 */
-	private char[] trustStorePassword;
-
-	/**
-	 * Provider Algorithm for the the SSL key store, for verifying the server.
-	 */
-	private String keyStoreProvider;
-
-	/**
-	 * Provider Algorithm for the SSL trust store used to verify the server.
-	 */
-	private String trustStoreProvider;
-
-	/**
-	 * TLS Protocol version for the SSL Context Values: TLSv1.2, TLSv1.3
-	 */
-	private String tlsProtocol;
-
-	/**
-	 * Type of SSL trust store, generally the default is used.
-	 */
-	private String trustStoreType;
-
-	public NatsConnectionProperties() {
-	}
-
-	/**
-	 * @return url for the nats server
-	 */
-	public String getServer() {
-		return this.server;
-	}
-
-	/**
-	 * @param server url for the nats server
-	 */
-	public void setServer(String server) {
-		this.server = server;
-	}
-
-	/**
-	 * @return a name used for the connection
-	 */
-	public String getConnectionName() {
-		return this.connectionName;
-	}
-
-	/**
-	 * @param connectionName a name to associate with the connection
-	 */
-	public void setConnectionName(String connectionName) {
-		this.connectionName = connectionName;
-	}
-
-	/**
-	 * @return maximum times to try to reconnect
-	 */
-	public int getMaxReconnect() {
-		return this.maxReconnect;
-	}
-
-	/**
-	 * @param maxReconnect maximum times to try to reconnect
-	 */
-	public void setMaxReconnect(int maxReconnect) {
-		this.maxReconnect = maxReconnect;
-	}
-
-	/**
-	 * @return time to wait between reconnect attempts on the same server url
-	 */
-	public Duration getReconnectWait() {
-		return this.reconnectWait;
-	}
-
-	/**
-	 * @param reconnectWait time to wait between reconnect attempts on the same
-	 *                      server url
-	 */
-	public void setReconnectWait(Duration reconnectWait) {
-		this.reconnectWait = reconnectWait;
-	}
-
-	/**
-	 * @return maximum time for initial connection
-	 */
-	public Duration getConnectionTimeout() {
-		return this.connectionTimeout;
-	}
-
-	/**
-	 * @param connectionTimeout maximum time for initial connection
-	 */
-	public void setConnectionTimeout(Duration connectionTimeout) {
-		this.connectionTimeout = connectionTimeout;
-	}
-
-	/**
-	 * @return time between server pings
-	 */
-	public Duration getPingInterval() {
-		return this.pingInterval;
-	}
-
-	/**
-	 * @param pingInterval time between server pings
-	 */
-	public void setPingInterval(Duration pingInterval) {
-		this.pingInterval = pingInterval;
-	}
-
-	/**
-	 * @return size of the buffer, in bytes, used to store publish messages during
-	 *         reconnect
-	 */
-	public long getReconnectBufferSize() {
-		return this.reconnectBufferSize;
-	}
-
-	/**
-	 * @param reconnectBufferSize size of the buffer, in bytes, used to store
-	 *                            publish messages during reconnect
-	 */
-	public void setReconnectBufferSize(long reconnectBufferSize) {
-		this.reconnectBufferSize = reconnectBufferSize;
-	}
-
-	/**
-	 * @return username to use with password for authenticaiton
-	 */
-	public String getUsername() {
-		return this.username;
-	}
-
-	/**
-	 * @param username to use with password for authenticaiton
-	 */
-	public void setUsername(String username) {
-		this.username = username;
-	}
-
-	/**
-	 * @return password to use with username for authenticaiton
-	 */
-	public String getPassword() {
-		return this.password;
-	}
-
-	/**
-	 * @param password to use with username for authenticaiton
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	/**
-	 * @return authentication token to use with the server
-	 */
-	public String getToken() {
-		return this.token;
-	}
-
-	/**
-	 * @param token authentication token to use with the server
-	 */
-	public void setToken(String token) {
-		this.token = token;
-	}
-
-	/**
-	 * @return private key (seed) for NKey authentication with the server
-	 */
-	public String getNkey() {
-		return nkey;
-	}
-
-	/**
-	 * @param nkey private key (seed) for NKey authentication with the server
-	 */
-	public void setNkey(String nkey) {
-		this.nkey = nkey;
-	}
-
-	/**
-	 * @return prefix to use for request/reply inboxes
-	 */
-	public String getInboxPrefix() {
-		return this.inboxPrefix;
-	}
-
-	/**
-	 * @param inboxPrefix custom prefix to use for request/reply inboxes
-	 */
-	public void setInboxPrefix(String inboxPrefix) {
-		this.inboxPrefix = inboxPrefix;
-	}
-
-	/**
-	 * @return whether or not to block echo messages, messages that were sent by
-	 *         this connection
-	 */
-	public boolean isNoEcho() {
-		return this.noEcho;
-	}
-
-	/**
-	 * @return whether or not to block echo messages, messages that were sent by
-	 *         this connection
-	 */
-	public boolean getNoEcho() {
-		return this.noEcho;
-	}
-
-	/**
-	 * @param noEcho enable or disable echo messages, messages that are sent by this
-	 *               connection back to this connection
-	 */
-	public void setNoEcho(boolean noEcho) {
-		this.noEcho = noEcho;
-	}
-
-	/**
-	 * @return whether or not the client should support for UTF8 subject names
-	 */
-	public boolean isUtf8Support() {
-		return this.utf8Support;
-	}
-
-	/**
-	 * @return whether or not the client should support for UTF8 subject names
-	 */
-	public boolean getUtf8Support() {
-		return this.utf8Support;
-	}
-
-	/**
-	 * @param utf8Support whether or not the client should support for UTF8 subject
-	 *                    names
-	 */
-	public void setUtf8Support(boolean utf8Support) {
-		this.utf8Support = utf8Support;
-	}
-
-	/**
-	 * @return path to the credentials file to use for authentication with an
-	 *         account enabled server
-	 */
-	public String getCredentials() {
-		return this.credentials;
-	}
-
-	/**
-	 * @param credentials path to the credentials file to use for authentication
-	 *                    with an account enabled server
-	 */
-	public void setCredentials(String credentials) {
-		this.credentials = credentials;
-	}
-
-	/**
-	 * @return path to the SSL Keystore
-	 */
-	public String getKeyStorePath() {
-		return this.keyStorePath;
-	}
-
-	/**
-	 * @param keyStorePath file path for the SSL Keystore
-	 */
-	public void setKeyStorePath(String keyStorePath) {
-		this.keyStorePath = keyStorePath;
-	}
-
-	/**
-	 * @return password used to unlock the keystore
-	 */
-	public char[] getKeyStorePassword() {
-		return this.keyStorePassword;
-	}
-
-	/**
-	 * @param keyStorePassword used to unlock the keystore
-	 */
-	public void setKeyStorePassword(char[] keyStorePassword) {
-		this.keyStorePassword = keyStorePassword;
-	}
-
-	/**
-	 * @return type of keystore to use for SSL connections
-	 */
-	public String getKeyStoreType() {
-		return this.keyStoreType;
-	}
-
-	/**
-	 * @param keyStoreType generally the default, but available for special keystore
-	 *                     formats/types
-	 */
-	public void setKeyStoreType(String keyStoreType) {
-		this.keyStoreType = keyStoreType;
-	}
-
-	/**
-	 * @return file path for the SSL trust store
-	 */
-	public String getTrustStorePath() {
-		return this.trustStorePath;
-	}
-
-	/**
-	 * @param trustStorePath file path for the SSL trust store
-	 */
-	public void setTrustStorePath(String trustStorePath) {
-		this.trustStorePath = trustStorePath;
-	}
-
-	/**
-	 * @return password used to unlock the trust store
-	 */
-	public char[] getTrustStorePassword() {
-		return this.trustStorePassword;
-	}
-
-	/**
-	 * @param trustStorePassword used to unlock the trust store
-	 */
-	public void setTrustStorePassword(char[] trustStorePassword) {
-		this.trustStorePassword = trustStorePassword;
-	}
-
-	/**
-	 * @return type of keystore to use for SSL connections
-	 */
-	public String getTrustStoreType() {
-		return this.trustStoreType;
-	}
-
-	/**
-	 * @param trustStoreType generally the default, but available for special trust
-	 *                       store formats/types
-	 */
-	public void setTrustStoreType(String trustStoreType) {
-		this.trustStoreType = trustStoreType;
-	}
-
-	/**
-	 * @return keyStoreProvider of keystore to use for SSL connections
-	 */
-	public String getKeyStoreProvider() {
-		return keyStoreProvider;
-	}
-
-	/**
-	 * @param keyStoreProvider defaults to SunX509. Alternatives include PKIX.
-	 */
-	public void setKeyStoreProvider(String keyStoreProvider) {
-		this.keyStoreProvider = keyStoreProvider;
-	}
-
-	/**
-	 * @return trustStoreProvider of keystore to use for SSL connections
-	 */
-	public String getTrustStoreProvider() {
-		return trustStoreProvider;
-	}
-
-	/**
-	 * @param trustStoreProvider defaults to SunX509. Alternatives include PKIX.
-	 */
-	public void setTrustStoreProvider(String trustStoreProvider) {
-		this.trustStoreProvider = trustStoreProvider;
-	}
-
-	/**
-	 * 
-	 * @return tlsProtocol to be used in TLS handshake
-	 */
-	public String getTlsProtocol() {
-		return tlsProtocol;
-	}
-
-	/**
-	 * @param trustStoreProvider defaults to TLSv1.2
-	 */
-	public void setTlsProtocol(String tlsProtocol) {
-		this.tlsProtocol = tlsProtocol;
-	}
-
-	/**
-	 * @param serverURL used for the underlying nats connection, can be a comma
-	 *                  separated list
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties server(String serverURL) {
-		this.server = serverURL;
-		return this;
-	}
-
-	/**
-	 * @param connectionName used for the underlying nats connection
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties connectionName(String connectionName) {
-		this.connectionName = connectionName;
-		return this;
-	}
-
-	/**
-	 * @param maxReconnect limit on the number of reconnect attempts to make, per
-	 *                     disconnect
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties maxReconnect(int maxReconnect) {
-		this.maxReconnect = maxReconnect;
-		return this;
-	}
-
-	/**
-	 * @param reconnectWait time to wait between reconnect attempts to the same
-	 *                      server url
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties reconnectWait(Duration reconnectWait) {
-		this.reconnectWait = reconnectWait;
-		return this;
-	}
-
-	/**
-	 * @param connectionTimeout maximum time to allow the initial connection to take
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties connectionTimeout(Duration connectionTimeout) {
-		this.connectionTimeout = connectionTimeout;
-		return this;
-	}
-
-	/**
-	 * @param pingInterval time between heartbeat pings to the server
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties pingInterval(Duration pingInterval) {
-		this.pingInterval = pingInterval;
-		return this;
-	}
-
-	/**
-	 * @param reconnectBufferSize size, in bytes, of the buffer used to store
-	 *                            outgoing messages during reconnect
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties reconnectBufferSize(long reconnectBufferSize) {
-		this.reconnectBufferSize = reconnectBufferSize;
-		return this;
-	}
-
-	/**
-	 * @param username for authentication
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties username(String username) {
-		this.username = username;
-		return this;
-	}
-
-	/**
-	 * @param password for authentication
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties password(String password) {
-		this.password = password;
-		return this;
-	}
-
-	/**
-	 * @param token for authentication
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties token(String token) {
-		this.token = token;
-		return this;
-	}
-
-	/**
-	 * @param nkey private key (seed) for NKey authentication
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties nkey(String nkey) {
-		this.nkey = nkey;
-		return this;
-	}
-
-	/**
-	 * @param inboxPrefix custom prefix to use for request/reply inboxes
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties inboxPrefix(String inboxPrefix) {
-		this.inboxPrefix = inboxPrefix;
-		return this;
-	}
-
-	/**
-	 * @param noEcho whether or not to send messages published by this connection
-	 *               back to it's subscribers
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties noEcho(boolean noEcho) {
-		this.noEcho = noEcho;
-		return this;
-	}
-
-	/**
-	 * @param utf8Support whether or not to support utf8 subject names
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties utf8Support(boolean utf8Support) {
-		this.utf8Support = utf8Support;
-		return this;
-	}
-
-	/**
-	 * @param credentials file path to the user credentials to use for
-	 *                    authentication
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties credentials(String credentials) {
-		this.credentials = credentials;
-		return this;
-	}
-
-	/**
-	 * @param keyStorePath file path to SSL Key Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties keyStorePath(String keyStorePath) {
-		this.keyStorePath = keyStorePath;
-		return this;
-	}
-
-	/**
-	 * @param keyStorePassword required to unlock the SSL Key Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties keyStorePassword(char[] keyStorePassword) {
-		this.keyStorePassword = keyStorePassword;
-		return this;
-	}
-
-	/**
-	 * @param trustStorePath file path to SSL Trust Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties trustStorePath(String trustStorePath) {
-		this.trustStorePath = trustStorePath;
-		return this;
-	}
-
-	/**
-	 * @param trustStorePassword required to unlock the SSL Trust Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties trustStorePassword(char[] trustStorePassword) {
-		setTrustStorePassword(trustStorePassword);
-		return this;
-	}
-
-	/**
-	 * @param keyStoreType type/format of the SSL Key Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties keyStoreType(String keyStoreType) {
-		this.keyStoreType = keyStoreType;
-		return this;
-	}
-
-	/**
-	 * @param keyStoreProvider of the SSL Key Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties keyStoreProvider(String keyStoreProvider) {
-		this.keyStoreProvider = keyStoreProvider;
-		return this;
-	}
-
-	/**
-	 * @param trustStoreType type/format of the SSL Trust Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties trustStoreType(String trustStoreType) {
-		this.trustStoreType = trustStoreType;
-		return this;
-	}
-
-	/**
-	 * @param trustStoreProvider of the SSL Trust Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties trustStoreProvider(String trustStoreProvider) {
-		this.trustStoreProvider = trustStoreProvider;
-		return this;
-	}
-
-	/**
-	 * @param trustStoreProvider of the SSL Trust Store
-	 * @return chainable properties
-	 */
-	public NatsConnectionProperties tlsProtocol(String tlsProtocol) {
-		this.tlsProtocol = tlsProtocol;
-		return this;
-	}
-
-	protected KeyStore loadKeystore(String path, char[] password, String keyStoreType)
-			throws IOException, GeneralSecurityException {
-		KeyStore store = KeyStore.getInstance(keyStoreType);
-
-		try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(path))) {
-			store.load(in, password);
-		}
-
-		return store;
-	}
-
-	protected KeyManager[] createKeyManagers(String path, char[] password, String keyStoreProvider, String keyStoreType)
-			throws IOException, GeneralSecurityException {
-		if (keyStoreProvider == null || keyStoreProvider.length() == 0) {
-			keyStoreProvider = defaultKeyStoreProviderAlgorithm;
-		}
-
-		if (keyStoreType == null || keyStoreType.length() == 0) {
-			keyStoreType = defaultKeyStoreType;
-		}
-
-		if (password == null || password.length == 0) {
-			password = new char[0];
-		}
-
-		KeyStore store = this.loadKeystore(path, password, keyStoreType);
-		KeyManagerFactory factory = KeyManagerFactory.getInstance(keyStoreProvider);
-		factory.init(store, password);
-		return factory.getKeyManagers();
-	}
-
-	protected TrustManager[] createTrustManagers(String path, char[] password, String trustStoreProvider,
-			String trustStoreType) throws IOException, GeneralSecurityException {
-		if (trustStoreProvider == null || trustStoreProvider.length() == 0) {
-			trustStoreProvider = defaultTrustStoreProviderAlgorithm;
-		}
-
-		if (trustStoreType == null || trustStoreType.length() == 0) {
-			trustStoreType = defaultTrustStoreType;
-		}
-
-		if (password == null || password.length == 0) {
-			password = new char[0];
-		}
-
-		KeyStore store = loadKeystore(path, password, trustStoreType);
-		TrustManagerFactory factory = TrustManagerFactory.getInstance(trustStoreProvider);
-		
-		/* 
-		 * Trust Store doesn't need to load any keys from the store (just certs)
-		 * so passing a password is not necessary
-		 */
-		factory.init(store); 
-		
-		return factory.getTrustManagers();
-	}
-
-	/**
-	 * Create a SSLContext with the given tlsProtocol
-	 * 
-	 * @return SSLContext
-	 * @throws IOException
-	 * @throws GeneralSecurityException
-	 */
-	protected SSLContext createSSLContext() throws IOException, GeneralSecurityException {
-		
-		if (this.tlsProtocol == null || this.tlsProtocol.length() == 0) {
-			this.tlsProtocol = Options.DEFAULT_SSL_PROTOCOL;
-		}
-
-		SSLContext ctx = SSLContext.getInstance(this.tlsProtocol);
-		ctx.init(
-				this.createKeyManagers(this.keyStorePath, this.keyStorePassword, this.keyStoreProvider,
-						this.keyStoreType),
-				this.createTrustManagers(this.trustStorePath, this.trustStorePassword, this.trustStoreProvider,
-						this.trustStoreType),
-				new SecureRandom());
-		return ctx;
-	}
-
-	/**
-	 * @return NATS options based on this set of properties
-	 * @throws IOException              if there is a problem reading a file or
-	 *                                  setting up the SSL context
-	 * @throws GeneralSecurityException if there is a problem setting up the SSL
-	 *                                  context
-	 */
-	public Options toOptions() throws IOException, GeneralSecurityException {
-		return toOptionsBuilder().build();
-	}
-
-	/**
-	 * @return NATS options builder based on this set of properties, useful if other
-	 *         settings are required before connect is called
-	 * @throws IOException              if there is a problem reading a file or
-	 *                                  setting up the SSL context
-	 * @throws GeneralSecurityException if there is a problem setting up the SSL
-	 *                                  context
-	 */
-	public Options.Builder toOptionsBuilder() throws IOException, GeneralSecurityException {
-		Options.Builder builder = new Options.Builder();
-
-		builder = builder.server(this.server);
-		builder = builder.maxReconnects(this.maxReconnect);
-		builder = builder.reconnectWait(this.reconnectWait);
-		builder = builder.connectionTimeout(this.connectionTimeout);
-		builder = builder.connectionName(this.connectionName);
-		builder = builder.pingInterval(this.pingInterval);
-		builder = builder.reconnectBufferSize(this.reconnectBufferSize);
-		builder = builder.inboxPrefix(this.inboxPrefix);
-
-		if (this.noEcho) {
-			builder = builder.noEcho();
-		}
-
-		if (this.utf8Support) {
-			builder = builder.supportUTF8Subjects();
-		}
-
-		if (this.nkey != null && this.nkey.length() > 0) {
-			builder = builder.authHandler(Nats.staticCredentials(null, this.nkey.toCharArray()));
-		} else if (this.credentials != null && this.credentials.length() > 0) {
-			builder = builder.authHandler(Nats.credentials(this.credentials));
-		} else if (this.token != null && this.token.length() > 0) {
-			builder = builder.token(this.token.toCharArray());
-		} else if (this.username != null && this.username.length() > 0) {
-			builder = builder.userInfo(this.username.toCharArray(), this.password.toCharArray());
-		}
-
-		if (this.keyStorePath != null && this.keyStorePath.length() > 0 && this.trustStorePath != null
-				&& this.trustStorePath.length() > 0) {
-			builder.sslContext(this.createSSLContext());
-		}
-
-		return builder;
-	}
-
-	@Override
-	public String toString() {
-		return "{" + " server='" + getServer() + "'," + " name='" + getConnectionName() + "'," + " maxReconnect='"
-				+ getMaxReconnect() + "'," + " reconnectWait='" + getReconnectWait() + "'," + " connectionTimeout='"
-				+ getConnectionTimeout() + "'," + " pingInterval='" + getPingInterval() + "',"
-				+ " reconnectBufferSize='" + getReconnectBufferSize() + "'," + " noEcho='" + getNoEcho() + "',"
-				+ " utf8='" + getUtf8Support() + "'," + " user='" + getUsername() + "'," + " password='" + getPassword()
-				+ "'," + " token='" + getToken() + "'," + " creds='" + getCredentials() + "'," + " nkey='" + getNkey()
-				+ "'," + "}";
-	}
+    
+    /**
+     * URL for the nats server, can be a comma separated list.
+     */
+    private String server;
+
+    /**
+     * Connection name, shows up in thread names.
+     */
+    private String connectionName;
+
+    /**
+     * Maximum reconnect attempts if a connection is lost, after the initial
+     * connection.
+     */
+    private int maxReconnect = Options.DEFAULT_MAX_RECONNECT;
+
+    /**
+     * Time to wait between reconnect attempts to the same server url.
+     */
+    private Duration reconnectWait = Options.DEFAULT_RECONNECT_WAIT;
+
+    /**
+     * Timeout for the initial connection, if this time is passed, the connection
+     * will fail and no reconnect attempts are made.
+     */
+    private Duration connectionTimeout = Options.DEFAULT_CONNECTION_TIMEOUT;
+
+    /**
+     * Time between pings to the server to check "liveness".
+     */
+    private Duration pingInterval = Options.DEFAULT_PING_INTERVAL;
+
+    /**
+     * Size of the buffer, in bytes, used to hold outgoing messages during
+     * reconnect.
+     */
+    private long reconnectBufferSize = Options.DEFAULT_RECONNECT_BUF_SIZE;
+
+    /**
+     * Prefix to use for inboxes, generally the default is used but custom prefixes
+     * can allow security controls.
+     */
+    private String inboxPrefix = Options.DEFAULT_INBOX_PREFIX;
+
+    /**
+     * Default KeyStore format/type for KeyManager instances
+     */
+    private final String defaultKeyStoreType = "PKCS12";
+
+    /**
+     * Default KeyStore format/type for TrustManager instances
+     */
+    private final String defaultTrustStoreType = "PKCS12";
+
+    /**
+     * Default KeyStore Provider Algorithm for KeyManager instances
+     */
+    private final String defaultKeyStoreProviderAlgorithm = "SunX509";
+
+    /**
+     * Default KeyStore Provider Algorithm for TrustManager instances
+     */
+    private final String defaultTrustStoreProviderAlgorithm = "SunX509";
+
+    /**
+     * Whether or not the server will send messages sent from this connection back
+     * to the connection.
+     */
+    private boolean noEcho;
+
+    /**
+     * Whether or not to treat subjects as UTF-8, the default is ASCII.
+     */
+    private boolean utf8Support;
+
+    /**
+     * Authentication user name. Requires the password, but not the token, or
+     * credentials, or NKey.
+     */
+    private String username;
+
+    /**
+     * Authentication password. Requires the username, but not the token, or
+     * credentials, or NKey.
+     */
+    private String password;
+
+    /**
+     * Authentication token, do not use with username/password, or credentials, or
+     * NKey.
+     */
+    private String token;
+
+    /**
+     * User credentials file path, do not use with user/password, or token, or NKey.
+     * Credentials are used by account enabled servers.
+     */
+    private String credentials;
+
+    /**
+     * Private key (seed) for NKey authentication, do not use with user/password, or
+     * token, or credentials.
+     */
+    private String nkey;
+
+    /**
+     * Path to the SSL keystore.
+     */
+    private String keyStorePath;
+
+    /**
+     * Password for the SSL keystore.
+     */
+    private char[] keyStorePassword;
+
+    /**
+     * Type of SSL keystore, generally the default is used.
+     */
+    private String keyStoreType;
+
+    /**
+     * Path the the SSL trust store, for verifying the server.
+     */
+    private String trustStorePath;
+
+    /**
+     * Password for the SSL trust store used to verify the server.
+     */
+    private char[] trustStorePassword;
+
+    /**
+     * Provider Algorithm for the the SSL key store, for verifying the server.
+     */
+    private String keyStoreProvider;
+
+    /**
+     * Provider Algorithm for the SSL trust store used to verify the server.
+     */
+    private String trustStoreProvider;
+
+    /**
+     * TLS Protocol version for the SSL Context. Values: TLSv1.2, TLSv1.3
+     */
+    private String tlsProtocol;
+
+    /**
+     * Type of SSL trust store, generally the default is used.
+     */
+    private String trustStoreType;
+
+    public NatsConnectionProperties() {
+    }
+
+    /**
+     * @return url for the nats server
+     */
+    public String getServer() {
+	return this.server;
+    }
+
+    /**
+     * @param server url for the nats server
+     */
+    public void setServer(String server) {
+	this.server = server;
+    }
+
+    /**
+     * @return a name used for the connection
+     */
+    public String getConnectionName() {
+	return this.connectionName;
+    }
+
+    /**
+     * @param connectionName a name to associate with the connection
+     */
+    public void setConnectionName(String connectionName) {
+	this.connectionName = connectionName;
+    }
+
+    /**
+     * @return maximum times to try to reconnect
+     */
+    public int getMaxReconnect() {
+	return this.maxReconnect;
+    }
+
+    /**
+     * @param maxReconnect maximum times to try to reconnect
+     */
+    public void setMaxReconnect(int maxReconnect) {
+	this.maxReconnect = maxReconnect;
+    }
+
+    /**
+     * @return time to wait between reconnect attempts on the same server url
+     */
+    public Duration getReconnectWait() {
+	return this.reconnectWait;
+    }
+
+    /**
+     * @param reconnectWait time to wait between reconnect attempts on the same
+     *                      server url
+     */
+    public void setReconnectWait(Duration reconnectWait) {
+	this.reconnectWait = reconnectWait;
+    }
+
+    /**
+     * @return maximum time for initial connection
+     */
+    public Duration getConnectionTimeout() {
+	return this.connectionTimeout;
+    }
+
+    /**
+     * @param connectionTimeout maximum time for initial connection
+     */
+    public void setConnectionTimeout(Duration connectionTimeout) {
+	this.connectionTimeout = connectionTimeout;
+    }
+
+    /**
+     * @return time between server pings
+     */
+    public Duration getPingInterval() {
+	return this.pingInterval;
+    }
+
+    /**
+     * @param pingInterval time between server pings
+     */
+    public void setPingInterval(Duration pingInterval) {
+	this.pingInterval = pingInterval;
+    }
+
+    /**
+     * @return size of the buffer, in bytes, used to store publish messages during
+     *         reconnect
+     */
+    public long getReconnectBufferSize() {
+	return this.reconnectBufferSize;
+    }
+
+    /**
+     * @param reconnectBufferSize size of the buffer, in bytes, used to store
+     *                            publish messages during reconnect
+     */
+    public void setReconnectBufferSize(long reconnectBufferSize) {
+	this.reconnectBufferSize = reconnectBufferSize;
+    }
+
+    /**
+     * @return username to use with password for authenticaiton
+     */
+    public String getUsername() {
+	return this.username;
+    }
+
+    /**
+     * @param username to use with password for authenticaiton
+     */
+    public void setUsername(String username) {
+	this.username = username;
+    }
+
+    /**
+     * @return password to use with username for authenticaiton
+     */
+    public String getPassword() {
+	return this.password;
+    }
+
+    /**
+     * @param password to use with username for authenticaiton
+     */
+    public void setPassword(String password) {
+	this.password = password;
+    }
+
+    /**
+     * @return authentication token to use with the server
+     */
+    public String getToken() {
+	return this.token;
+    }
+
+    /**
+     * @param token authentication token to use with the server
+     */
+    public void setToken(String token) {
+	this.token = token;
+    }
+
+    /**
+     * @return private key (seed) for NKey authentication with the server
+     */
+    public String getNkey() {
+	return nkey;
+    }
+
+    /**
+     * @param nkey private key (seed) for NKey authentication with the server
+     */
+    public void setNkey(String nkey) {
+	this.nkey = nkey;
+    }
+
+    /**
+     * @return prefix to use for request/reply inboxes
+     */
+    public String getInboxPrefix() {
+	return this.inboxPrefix;
+    }
+
+    /**
+     * @param inboxPrefix custom prefix to use for request/reply inboxes
+     */
+    public void setInboxPrefix(String inboxPrefix) {
+	this.inboxPrefix = inboxPrefix;
+    }
+
+    /**
+     * @return whether or not to block echo messages, messages that were sent by
+     *         this connection
+     */
+    public boolean isNoEcho() {
+	return this.noEcho;
+    }
+
+    /**
+     * @return whether or not to block echo messages, messages that were sent by
+     *         this connection
+     */
+    public boolean getNoEcho() {
+	return this.noEcho;
+    }
+
+    /**
+     * @param noEcho enable or disable echo messages, messages that are sent by this
+     *               connection back to this connection
+     */
+    public void setNoEcho(boolean noEcho) {
+	this.noEcho = noEcho;
+    }
+
+    /**
+     * @return whether or not the client should support for UTF8 subject names
+     */
+    public boolean isUtf8Support() {
+	return this.utf8Support;
+    }
+
+    /**
+     * @return whether or not the client should support for UTF8 subject names
+     */
+    public boolean getUtf8Support() {
+	return this.utf8Support;
+    }
+
+    /**
+     * @param utf8Support whether or not the client should support for UTF8 subject
+     *                    names
+     */
+    public void setUtf8Support(boolean utf8Support) {
+	this.utf8Support = utf8Support;
+    }
+
+    /**
+     * @return path to the credentials file to use for authentication with an
+     *         account enabled server
+     */
+    public String getCredentials() {
+	return this.credentials;
+    }
+
+    /**
+     * @param credentials path to the credentials file to use for authentication
+     *                    with an account enabled server
+     */
+    public void setCredentials(String credentials) {
+	this.credentials = credentials;
+    }
+
+    /**
+     * @return path to the SSL Keystore
+     */
+    public String getKeyStorePath() {
+	return this.keyStorePath;
+    }
+
+    /**
+     * @param keyStorePath file path for the SSL Keystore
+     */
+    public void setKeyStorePath(String keyStorePath) {
+	this.keyStorePath = keyStorePath;
+    }
+
+    /**
+     * @return password used to unlock the keystore
+     */
+    public char[] getKeyStorePassword() {
+	return this.keyStorePassword;
+    }
+
+    /**
+     * @param keyStorePassword used to unlock the keystore
+     */
+    public void setKeyStorePassword(char[] keyStorePassword) {
+	this.keyStorePassword = keyStorePassword;
+    }
+
+    /**
+     * @return type of keystore to use for SSL connections
+     */
+    public String getKeyStoreType() {
+	return this.keyStoreType;
+    }
+
+    /**
+     * @param keyStoreType generally the default, but available for special keystore
+     *                     formats/types
+     */
+    public void setKeyStoreType(String keyStoreType) {
+	this.keyStoreType = keyStoreType;
+    }
+
+    /**
+     * @return file path for the SSL trust store
+     */
+    public String getTrustStorePath() {
+	return this.trustStorePath;
+    }
+
+    /**
+     * @param trustStorePath file path for the SSL trust store
+     */
+    public void setTrustStorePath(String trustStorePath) {
+	this.trustStorePath = trustStorePath;
+    }
+
+    /**
+     * @return password used to unlock the trust store
+     */
+    public char[] getTrustStorePassword() {
+	return this.trustStorePassword;
+    }
+
+    /**
+     * @param trustStorePassword used to unlock the trust store
+     */
+    public void setTrustStorePassword(char[] trustStorePassword) {
+	this.trustStorePassword = trustStorePassword;
+    }
+
+    /**
+     * @return type of keystore to use for SSL connections
+     */
+    public String getTrustStoreType() {
+	return this.trustStoreType;
+    }
+
+    /**
+     * @param trustStoreType generally the default, but available for special trust
+     *                       store formats/types
+     */
+    public void setTrustStoreType(String trustStoreType) {
+	this.trustStoreType = trustStoreType;
+    }
+
+    /**
+     * @return keyStoreProvider of keystore to use for SSL connections
+     */
+    public String getKeyStoreProvider() {
+	return keyStoreProvider;
+    }
+
+    /**
+     * @param keyStoreProvider defaults to SunX509. Alternatives include PKIX.
+     */
+    public void setKeyStoreProvider(String keyStoreProvider) {
+	this.keyStoreProvider = keyStoreProvider;
+    }
+
+    /**
+     * @return trustStoreProvider of keystore to use for SSL connections
+     */
+    public String getTrustStoreProvider() {
+	return trustStoreProvider;
+    }
+
+    /**
+     * @param trustStoreProvider defaults to SunX509. Alternatives include PKIX.
+     */
+    public void setTrustStoreProvider(String trustStoreProvider) {
+	this.trustStoreProvider = trustStoreProvider;
+    }
+
+    /**
+     * 
+     * @return tlsProtocol to be used in TLS handshake
+     */
+    public String getTlsProtocol() {
+	return tlsProtocol;
+    }
+
+    /**
+     * @param trustStoreProvider defaults to TLSv1.2
+     */
+    public void setTlsProtocol(String tlsProtocol) {
+	this.tlsProtocol = tlsProtocol;
+    }
+
+    /**
+     * @param serverURL used for the underlying nats connection, can be a comma
+     *                  separated list
+     * @return chainable properties
+     */
+    public NatsConnectionProperties server(String serverURL) {
+	this.server = serverURL;
+	return this;
+    }
+
+    /**
+     * @param connectionName used for the underlying nats connection
+     * @return chainable properties
+     */
+    public NatsConnectionProperties connectionName(String connectionName) {
+	this.connectionName = connectionName;
+	return this;
+    }
+
+    /**
+     * @param maxReconnect limit on the number of reconnect attempts to make, per
+     *                     disconnect
+     * @return chainable properties
+     */
+    public NatsConnectionProperties maxReconnect(int maxReconnect) {
+	this.maxReconnect = maxReconnect;
+	return this;
+    }
+
+    /**
+     * @param reconnectWait time to wait between reconnect attempts to the same
+     *                      server url
+     * @return chainable properties
+     */
+    public NatsConnectionProperties reconnectWait(Duration reconnectWait) {
+	this.reconnectWait = reconnectWait;
+	return this;
+    }
+
+    /**
+     * @param connectionTimeout maximum time to allow the initial connection to take
+     * @return chainable properties
+     */
+    public NatsConnectionProperties connectionTimeout(Duration connectionTimeout) {
+	this.connectionTimeout = connectionTimeout;
+	return this;
+    }
+
+    /**
+     * @param pingInterval time between heartbeat pings to the server
+     * @return chainable properties
+     */
+    public NatsConnectionProperties pingInterval(Duration pingInterval) {
+	this.pingInterval = pingInterval;
+	return this;
+    }
+
+    /**
+     * @param reconnectBufferSize size, in bytes, of the buffer used to store
+     *                            outgoing messages during reconnect
+     * @return chainable properties
+     */
+    public NatsConnectionProperties reconnectBufferSize(long reconnectBufferSize) {
+	this.reconnectBufferSize = reconnectBufferSize;
+	return this;
+    }
+
+    /**
+     * @param username for authentication
+     * @return chainable properties
+     */
+    public NatsConnectionProperties username(String username) {
+	this.username = username;
+	return this;
+    }
+
+    /**
+     * @param password for authentication
+     * @return chainable properties
+     */
+    public NatsConnectionProperties password(String password) {
+	this.password = password;
+	return this;
+    }
+
+    /**
+     * @param token for authentication
+     * @return chainable properties
+     */
+    public NatsConnectionProperties token(String token) {
+	this.token = token;
+	return this;
+    }
+
+    /**
+     * @param nkey private key (seed) for NKey authentication
+     * @return chainable properties
+     */
+    public NatsConnectionProperties nkey(String nkey) {
+	this.nkey = nkey;
+	return this;
+    }
+
+    /**
+     * @param inboxPrefix custom prefix to use for request/reply inboxes
+     * @return chainable properties
+     */
+    public NatsConnectionProperties inboxPrefix(String inboxPrefix) {
+	this.inboxPrefix = inboxPrefix;
+	return this;
+    }
+
+    /**
+     * @param noEcho whether or not to send messages published by this connection
+     *               back to it's subscribers
+     * @return chainable properties
+     */
+    public NatsConnectionProperties noEcho(boolean noEcho) {
+	this.noEcho = noEcho;
+	return this;
+    }
+
+    /**
+     * @param utf8Support whether or not to support utf8 subject names
+     * @return chainable properties
+     */
+    public NatsConnectionProperties utf8Support(boolean utf8Support) {
+	this.utf8Support = utf8Support;
+	return this;
+    }
+
+    /**
+     * @param credentials file path to the user credentials to use for
+     *                    authentication
+     * @return chainable properties
+     */
+    public NatsConnectionProperties credentials(String credentials) {
+	this.credentials = credentials;
+	return this;
+    }
+
+    /**
+     * @param keyStorePath file path to SSL Key Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties keyStorePath(String keyStorePath) {
+	this.keyStorePath = keyStorePath;
+	return this;
+    }
+
+    /**
+     * @param keyStorePassword required to unlock the SSL Key Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties keyStorePassword(char[] keyStorePassword) {
+	this.keyStorePassword = keyStorePassword;
+	return this;
+    }
+
+    /**
+     * @param trustStorePath file path to SSL Trust Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties trustStorePath(String trustStorePath) {
+	this.trustStorePath = trustStorePath;
+	return this;
+    }
+
+    /**
+     * @param trustStorePassword required to unlock the SSL Trust Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties trustStorePassword(char[] trustStorePassword) {
+	setTrustStorePassword(trustStorePassword);
+	return this;
+    }
+
+    /**
+     * @param keyStoreType type/format of the SSL Key Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties keyStoreType(String keyStoreType) {
+	this.keyStoreType = keyStoreType;
+	return this;
+    }
+
+    /**
+     * @param keyStoreProvider of the SSL Key Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties keyStoreProvider(String keyStoreProvider) {
+	this.keyStoreProvider = keyStoreProvider;
+	return this;
+    }
+
+    /**
+     * @param trustStoreType type/format of the SSL Trust Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties trustStoreType(String trustStoreType) {
+	this.trustStoreType = trustStoreType;
+	return this;
+    }
+
+    /**
+     * @param trustStoreProvider of the SSL Trust Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties trustStoreProvider(String trustStoreProvider) {
+	this.trustStoreProvider = trustStoreProvider;
+	return this;
+    }
+
+    /**
+     * @param trustStoreProvider of the SSL Trust Store
+     * @return chainable properties
+     */
+    public NatsConnectionProperties tlsProtocol(String tlsProtocol) {
+	this.tlsProtocol = tlsProtocol;
+	return this;
+    }
+
+    protected KeyStore loadKeystore(String path, char[] password, String keyStoreType)
+	    throws IOException, GeneralSecurityException {
+	KeyStore store = KeyStore.getInstance(keyStoreType);
+
+	try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(path))) {
+	    store.load(in, password);
+	}
+
+	return store;
+    }
+
+    protected KeyManager[] createKeyManagers(String path, char[] password, String keyStoreProvider, String keyStoreType)
+	    throws IOException, GeneralSecurityException {
+	
+	if (keyStoreProvider == null || keyStoreProvider.length() == 0) {
+	    keyStoreProvider = defaultKeyStoreProviderAlgorithm;
+	}
+
+	if (keyStoreType == null || keyStoreType.length() == 0) {
+	    keyStoreType = defaultKeyStoreType;
+	}
+
+	if (password == null || password.length == 0) {
+	    password = new char[0];
+	}
+
+	KeyStore store = this.loadKeystore(path, password, keyStoreType);
+	KeyManagerFactory factory = KeyManagerFactory.getInstance(keyStoreProvider);
+	factory.init(store, password);
+	
+	return factory.getKeyManagers();
+    }
+
+    protected TrustManager[] createTrustManagers(String path, char[] password, String trustStoreProvider,
+	    String trustStoreType) throws IOException, GeneralSecurityException {
+
+	if (trustStoreProvider == null || trustStoreProvider.length() == 0) {
+	    trustStoreProvider = defaultTrustStoreProviderAlgorithm;
+	}
+
+	if (trustStoreType == null || trustStoreType.length() == 0) {
+	    trustStoreType = defaultTrustStoreType;
+	}
+
+	if (password == null || password.length == 0) {
+	    password = new char[0];
+	}
+
+	KeyStore store = loadKeystore(path, password, trustStoreType);
+	TrustManagerFactory factory = TrustManagerFactory.getInstance(trustStoreProvider);
+
+	/*
+	 * Trust Store doesn't need to load any keys from the store (just certs) so
+	 * passing a password is not necessary
+	 */
+	factory.init(store);
+
+	return factory.getTrustManagers();
+    }
+
+    /**
+     * @return SSLContext with the specified TLS protocol, Key and Trust stores.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     */
+    protected SSLContext createSSLContext() throws IOException, GeneralSecurityException {
+
+	if (this.tlsProtocol == null || this.tlsProtocol.length() == 0) {
+	    this.tlsProtocol = Options.DEFAULT_SSL_PROTOCOL;
+	}
+
+	SSLContext sslContext = SSLContext.getInstance(this.tlsProtocol);
+
+	KeyManager[] keyManagers = createKeyManagers(
+		this.keyStorePath,
+		this.keyStorePassword, 
+		this.keyStoreProvider,
+		this.keyStoreType
+	);
+	
+	TrustManager[] trustManagers = createTrustManagers(
+		this.trustStorePath,
+		this.trustStorePassword,
+		this.trustStoreProvider, 
+		this.trustStoreType
+	);
+
+	sslContext.init(keyManagers, trustManagers, new SecureRandom());
+
+	return sslContext;
+    }
+
+    /**
+     * @return NATS options based on this set of properties
+     * @throws IOException              if there is a problem reading a file or
+     *                                  setting up the SSL context
+     * @throws GeneralSecurityException if there is a problem setting up the SSL
+     *                                  context
+     */
+    public Options toOptions() throws IOException, GeneralSecurityException {
+	return toOptionsBuilder().build();
+    }
+
+    /**
+     * @return NATS options builder based on this set of properties, useful if other
+     *         settings are required before connect is called
+     * @throws IOException              if there is a problem reading a file or
+     *                                  setting up the SSL context
+     * @throws GeneralSecurityException if there is a problem setting up the SSL
+     *                                  context
+     */
+    public Options.Builder toOptionsBuilder() throws IOException, GeneralSecurityException {
+	Options.Builder builder = new Options.Builder();
+
+	builder = builder.server(this.server);
+	builder = builder.maxReconnects(this.maxReconnect);
+	builder = builder.reconnectWait(this.reconnectWait);
+	builder = builder.connectionTimeout(this.connectionTimeout);
+	builder = builder.connectionName(this.connectionName);
+	builder = builder.pingInterval(this.pingInterval);
+	builder = builder.reconnectBufferSize(this.reconnectBufferSize);
+	builder = builder.inboxPrefix(this.inboxPrefix);
+
+	if (this.noEcho) {
+	    builder = builder.noEcho();
+	}
+
+	if (this.utf8Support) {
+	    builder = builder.supportUTF8Subjects();
+	}
+
+	if (this.nkey != null && this.nkey.length() > 0) {
+	    builder = builder.authHandler(Nats.staticCredentials(null, this.nkey.toCharArray()));
+	} else if (this.credentials != null && this.credentials.length() > 0) {
+	    builder = builder.authHandler(Nats.credentials(this.credentials));
+	} else if (this.token != null && this.token.length() > 0) {
+	    builder = builder.token(this.token.toCharArray());
+	} else if (this.username != null && this.username.length() > 0) {
+	    builder = builder.userInfo(this.username.toCharArray(), this.password.toCharArray());
+	}
+
+	if (this.keyStorePath != null && this.keyStorePath.length() > 0 && this.trustStorePath != null
+		&& this.trustStorePath.length() > 0) {
+	    builder.sslContext(this.createSSLContext());
+	}
+
+	return builder;
+    }
+
+    @Override
+    public String toString() {
+	return "{" +
+        " server='" + getServer() + "'," +
+	" name='" + getConnectionName() + "'," +
+        " maxReconnect='" + getMaxReconnect() + "'," +
+	" reconnectWait='" + getReconnectWait() + "'," +
+        " connectionTimeout='" + getConnectionTimeout() + "'," +
+	" pingInterval='" + getPingInterval() + "'," +
+        " reconnectBufferSize='" + getReconnectBufferSize() + "'," +
+	" noEcho='" + getNoEcho() + "'," +
+        " utf8='" + getUtf8Support() + "'," +
+	" user='" + getUsername() + "'," +
+        " password='" + getPassword() + "'," +
+	" token='" + getToken() + "'," +
+        " creds='" + getCredentials() + "'," +
+	" nkey='" + getNkey() + "'," +
+        "}";
+    }
 
 }

--- a/nats-spring/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/nats-spring/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,158 @@
+{
+  "groups": [
+    {
+      "name": "nats.spring",
+      "type": "io.nats.spring.boot.autoconfigure.NatsProperties",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "nats.spring.connection-name",
+      "type": "java.lang.String",
+      "description": "Connection name, shows up in thread names.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.connection-timeout",
+      "type": "java.time.Duration",
+      "description": "Timeout for the initial connection, if this time is passed, the connection will fail and no reconnect attempts are made.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.credentials",
+      "type": "java.lang.String",
+      "description": "User credentials file path, do not use with user\/password, or token, or NKey. Credentials are used by account enabled servers.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.inbox-prefix",
+      "type": "java.lang.String",
+      "description": "Prefix to use for inboxes, generally the default is used but custom prefixes can allow security controls.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.key-store-password",
+      "type": "java.lang.Character[]",
+      "description": "Password for the SSL keystore.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.key-store-path",
+      "type": "java.lang.String",
+      "description": "Path to the SSL keystore.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.key-store-provider",
+      "type": "java.lang.String",
+      "description": "Provider Algorithm for the the SSL key store, for verifying the server.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.key-store-type",
+      "type": "java.lang.String",
+      "description": "Type of SSL keystore, generally the default is used.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.max-reconnect",
+      "type": "java.lang.Integer",
+      "description": "Maximum reconnect attempts if a connection is lost, after the initial connection.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.nkey",
+      "type": "java.lang.String",
+      "description": "Private key (seed) for NKey authentication, do not use with user\/password, or token, or credentials.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.no-echo",
+      "type": "java.lang.Boolean",
+      "description": "Whether or not the server will send messages sent from this connection back to the connection.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties",
+      "defaultValue": false
+    },
+    {
+      "name": "nats.spring.password",
+      "type": "java.lang.String",
+      "description": "Authentication password. Requires the username, but not the token, or credentials, or NKey.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.ping-interval",
+      "type": "java.time.Duration",
+      "description": "Time between pings to the server to check \"liveness\".",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.reconnect-buffer-size",
+      "type": "java.lang.Long",
+      "description": "Size of the buffer, in bytes, used to hold outgoing messages during reconnect.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.reconnect-wait",
+      "type": "java.time.Duration",
+      "description": "Time to wait between reconnect attempts to the same server url.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.server",
+      "type": "java.lang.String",
+      "description": "URL for the nats server, can be a comma separated list.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.tls-protocol",
+      "type": "java.lang.String",
+      "description": "TLS Protocol version for the SSL Context Values: TLSv1.2, TLSv1.3",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.token",
+      "type": "java.lang.String",
+      "description": "Authentication token, do not use with username\/password, or credentials, or NKey.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.trust-store-password",
+      "type": "java.lang.Character[]",
+      "description": "Password for the SSL trust store used to verify the server.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.trust-store-path",
+      "type": "java.lang.String",
+      "description": "Path the the SSL trust store, for verifying the server.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.trust-store-provider",
+      "type": "java.lang.String",
+      "description": "Provider Algorithm for the SSL trust store used to verify the server.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.trust-store-type",
+      "type": "java.lang.String",
+      "description": "Type of SSL trust store, generally the default is used.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.username",
+      "type": "java.lang.String",
+      "description": "Authentication user name. Requires the password, but not the token, or credentials, or NKey.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties"
+    },
+    {
+      "name": "nats.spring.utf8-support",
+      "type": "java.lang.Boolean",
+      "description": "Whether or not to treat subjects as UTF-8, the default is ASCII.",
+      "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties",
+      "defaultValue": false
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
**This changeset is about** 

1. Allow to specify KeyStore format for Key Store and Trust Store in connection properties. KeyStore format/type is now adjustable with:

```
nats.spring.key-store-type=JKS
nats.spring.trust-store-type=PKCS12
```

2. Key Store provider algorithm for these are now adjustable with:

```
nats.spring.key-store-provider=SunX509
nats.spring.trust-store-provider=PKIX
```

3. Also add support for adjusting TLS protocol version:

`nats.spring.tls-protocol=TLSv1.3`

4. Also add `spring-configuration-metadata.json` to the `META-INF` directory to assist IDEs while editing Spring Boot `application.properties` files.

Fixes https://github.com/nats-io/spring-nats/issues/25