### PR TITLE
feat(springboot):added spring boot 3 compatibility

### DIFF
--- a/nats-spring/src/main/resources/META-INF/spring.factories
+++ b/nats-spring/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
-# Auto Configure
+# Auto Configure (deprecated with spring boot 2.7)
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.nats.spring.boot.autoconfigure.NatsAutoConfiguration

--- a/nats-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/nats-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.nats.spring.boot.autoconfigure.NatsAutoConfiguration


### PR DESCRIPTION
Closes #38 #40  
Docs: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files

### Summary
This PR introduces a significant update to our library to maintain compatibility with Spring Boot 2.7 and newer versions, while ensuring backward compatibility with older versions. We've adopted the new AutoConfiguration.imports mechanism introduced in Spring Boot 2.7 for auto-configuration, along with retaining the existing spring.factories approach for older versions.

### Changes
Added META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports with an entry for io.nats.spring.boot.autoconfigure.NatsAutoConfiguration.
Retained the existing spring.factories entry to ensure backward compatibility with older Spring Boot versions.
Updated NatsAutoConfiguration with necessary Spring Boot configurations and conditional checks.

### Rationale
Spring Boot 2.7 introduced a more streamlined way to handle auto-configuration through AutoConfiguration.imports. This new approach simplifies the management of auto-configurations but requires changes to maintain compatibility. By supporting both the new and old methods, we ensure that our library remains functional across a wide range of Spring Boot versions, enhancing its usability and reliability.

### Impact
This change has no breaking impact on existing implementations using older versions of Spring Boot.
Users of Spring Boot 2.7 and newer will benefit from the improved auto-configuration process.