### PR TITLE
Add `docker-compose` support

### DIFF
--- a/nats-spring-docker-compose/pom.xml
+++ b/nats-spring-docker-compose/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.nats</groupId>
+        <artifactId>nats-spring-parent</artifactId>
+        <version>0.6.0-3.1</version>
+    </parent>
+
+    <artifactId>nats-spring-docker-compose</artifactId>
+    <name>Nats Spring Docker Compose</name>
+    <description>Nats Docker Compose Integration</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.nats</groupId>
+            <artifactId>nats-spring</artifactId>
+            <version>0.6.0-3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nats-spring-docker-compose/src/main/java/io/nats/docker/compose/NatsDockerComposeConnectionDetailsFactory.java
+++ b/nats-spring-docker-compose/src/main/java/io/nats/docker/compose/NatsDockerComposeConnectionDetailsFactory.java
@@ -1,0 +1,39 @@
+package io.nats.docker.compose;
+
+import io.nats.spring.boot.autoconfigure.NatsConnectionDetails;
+import org.springframework.boot.docker.compose.core.RunningService;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionDetailsFactory;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionSource;
+
+/**
+ * {@link DockerComposeConnectionDetailsFactory} to create {@link NatsConnectionDetails} for a {@code Nats}
+ *
+ * @author Kunal Varpe
+ */
+class NatsDockerComposeConnectionDetailsFactory extends DockerComposeConnectionDetailsFactory<NatsConnectionDetails> {
+    private static final String NATS_CONTAINER_NAME = "nats";
+    private static final int NAST_PORT = 4222;
+
+    NatsDockerComposeConnectionDetailsFactory(String connectionName) {
+        super(NATS_CONTAINER_NAME);
+    }
+
+    @Override
+    protected NatsConnectionDetails getDockerComposeConnectionDetails(DockerComposeConnectionSource source) {
+        return new NatsDockerComposeConnectionDetails(source.getRunningService());
+    }
+
+    private static final class NatsDockerComposeConnectionDetails extends DockerComposeConnectionDetails implements NatsConnectionDetails {
+
+        private final String server;
+
+        public NatsDockerComposeConnectionDetails(RunningService service) {
+            super(service);
+            this.server = "nats://%s:%s".formatted(service.host(), service.ports().get(NAST_PORT));
+        }
+
+        public String getServer() {
+            return this.server;
+        }
+    }
+}

--- a/nats-spring-docker-compose/src/main/resources/META-INF/spring.factories
+++ b/nats-spring-docker-compose/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
+io.nats.docker.compose.NatsDockerComposeConnectionDetailsFactory

--- a/nats-spring-docker-compose/src/test/java/io/nats/docker/compose/NatsDockerComposeConnectionDetailsFactoryTest.java
+++ b/nats-spring-docker-compose/src/test/java/io/nats/docker/compose/NatsDockerComposeConnectionDetailsFactoryTest.java
@@ -1,0 +1,45 @@
+package io.nats.docker.compose;
+
+import io.nats.spring.boot.autoconfigure.NatsConnectionDetails;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NatsDockerComposeConnectionDetailsFactoryTest {
+
+    private final Resource dockerComposeResource = new ClassPathResource("docker-compose.yaml");
+
+    @AfterAll
+    static void down() {
+        var shutdownHandlers = SpringApplication.getShutdownHandlers();
+        ((Runnable) shutdownHandlers).run();
+    }
+
+    @Test
+    void shouldAccessNatsServerWhenRun() throws IOException {
+        var application = new SpringApplication(TestConfig.class);
+        var properties = new LinkedHashMap<String, Object>();
+        properties.put("spring.docker.compose.skip.in-tests", "false");
+        properties.put("spring.docker.compose.file", dockerComposeResource.getFile());
+        properties.put("spring.docker.compose.stop.command", "down");
+        application.setDefaultProperties(properties);
+
+        var connectionDetails = application.run().getBean(NatsConnectionDetails.class);
+
+        assertThat(connectionDetails.getServer()).satisfiesAnyOf(
+                endpoint -> assertThat(endpoint).isEqualTo("nats://localhost:4222"),
+                endpoint -> assertThat(endpoint).isEqualTo("nats://127.0.0.1:4222"));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestConfig {
+    }
+}

--- a/nats-spring-docker-compose/src/test/resources/docker-compose.yaml
+++ b/nats-spring-docker-compose/src/test/resources/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  nats:
+    image: nats
+    ports:
+      - "4222:4222"

--- a/nats-spring-samples/docker-compose-sample/docker-compose.yaml
+++ b/nats-spring-samples/docker-compose-sample/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  nats:
+    image: nats
+    ports:
+      - "4222:4222"

--- a/nats-spring-samples/docker-compose-sample/pom.xml
+++ b/nats-spring-samples/docker-compose-sample/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>nats-spring-samples-autoconfigure</artifactId>
+    <artifactId>nats-spring-samples-docker-compose</artifactId>
     <version>0.6.0-3.1</version>
     <packaging>jar</packaging>
-    <name>autoconfigure-sample</name>
-    <description>A spring boot app that uses the autoconfigure NATS connection</description>
+    <name>docker-compose-sample</name>
 
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
@@ -24,6 +24,13 @@
             <groupId>io.nats</groupId>
             <artifactId>nats-spring</artifactId>
             <version>0.6.0-3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.nats</groupId>
+            <artifactId>nats-spring-docker-compose</artifactId>
+            <version>0.6.0-3.1</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/nats-spring-samples/docker-compose-sample/src/main/java/io/nats/spring/DockerComposeSample.java
+++ b/nats-spring-samples/docker-compose-sample/src/main/java/io/nats/spring/DockerComposeSample.java
@@ -1,0 +1,45 @@
+package io.nats.spring;
+
+import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.nio.charset.StandardCharsets;
+
+@SpringBootApplication
+public class DockerComposeSample {
+    public static void main(String[] args) {
+        SpringApplication.run(DockerComposeSample.class);
+    }
+
+    private static final Log logger = LogFactory.getLog(DockerComposeSample.class);
+    private Dispatcher dispatcher;
+
+    @Bean
+    ApplicationRunner runner(Connection nc) {
+        return args -> {
+            logger.info("starting autoconfigure listener with connection " + nc);
+
+            this.dispatcher = nc.createDispatcher(m -> {
+                logger.info("received message on " + m.getSubject() + " with reply to " + m.getReplyTo());
+                if (m.getReplyTo() != null) {
+                    nc.publish(m.getReplyTo(), m.getData());
+                }
+            });
+
+            String subject = "dataIn";
+
+            if (args.getSourceArgs().length > 0) {
+                subject = args.getSourceArgs()[0];
+            }
+
+            logger.info("subscribing to " + subject);
+            this.dispatcher.subscribe(subject);
+        };
+    }
+}

--- a/nats-spring-samples/docker-compose-sample/src/main/resources/application.properties
+++ b/nats-spring-samples/docker-compose-sample/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+spring.application.name=nats-docker-compose-sample
+
+# Notice we have not provided nats server related property it is getting pickup from docker compose file.
+
+spring.docker.compose.file=nats-spring-samples/docker-compose-sample/docker-compose.yaml
+
+logging.level.root=INFO

--- a/nats-spring-samples/pom.xml
+++ b/nats-spring-samples/pom.xml
@@ -29,6 +29,7 @@
         <module>multi-connect-sample</module>
         <module>autoconfigure-sample</module>
         <module>connect-error-sample</module>
+        <module>docker-compose-sample</module>
     </modules>
 
     <dependencyManagement>

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionDetails.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionDetails.java
@@ -1,0 +1,23 @@
+package io.nats.spring.boot.autoconfigure;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+import org.springframework.lang.Nullable;
+
+/**
+ * Details required to make connection to Nats Server.
+ *
+ * @author Kunal Varpe
+ */
+public interface NatsConnectionDetails extends ConnectionDetails {
+
+    /**
+     * Nats server url
+     *
+     * @return the nats server url
+     */
+    @Nullable
+    default String getServer() {
+        return null;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <modules>
         <module>nats-spring</module>
         <module>nats-spring-boot-starter</module>
+        <module>nats-spring-docker-compose</module>
         <module>nats-spring-cloud-stream-binder</module>
         <module>nats-spring-samples</module>
     </modules>
@@ -104,7 +105,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
# This MR
Add support for docker compose to spring nats

# What changes
Now you can create docker compose file in the root directory and when spring boot app starts it will spin up nats server and bind with app.

Closes gh-50