### PR TITLE
Add functional model binder coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ and include a dependency on the library:
 
 See the [Spring Cloud Stream Documentation](https://spring.io/projects/spring-cloud-stream) for information about more complex configurations of the bindings.
 
+Spring Cloud Stream functional applications are supported. Bind `Consumer`, `Function`, or `StreamBridge` applications with the standard functional binding names such as `input-in-0`, `transform-in-0`, and `transform-out-0`; see `nats-spring-samples` and `demo` for working examples.
+
 The NATS binder leverages the autoconfigure module, or manual configuration to build a NATS connection. Standard properties are used to specify inputs and outputs. Inputs, specified with a destination and group name are mapped to subjects and queue names, with the destination becoming the subject, and the group becoming the queue. Outputs are specified with a destination name that becomes the subject.
 
 Consumers are implemented with a dispatcher. Each consumer will create its own dispatcher in the core library, resulting in a thread per consumer.

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,6 +4,8 @@ Standalone Spring Boot demo for the NATS Spring Cloud Stream binder.
 
 It uses the Spring Cloud Stream functional model with a `Function` bean named `transform`.
 
+Requires Java 17 and runs on Spring Boot 3.5.x with Spring Cloud Stream 4.2.x.
+
 To run:
 
 ```bash

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,15 +1,14 @@
-# NATS Streaming Binder Example
+# NATS Spring Cloud Stream Binder Demo
 
-This is a simple example using the NATS Streaming binder. The example lives independently of the other samples, with
-only the SpringBoot parent pom.
+Standalone Spring Boot demo for the NATS Spring Cloud Stream binder.
 
-The example is similar to the processor examples from the nats-samples folder, but shows how to include the binder
-independently.
+It uses the Spring Cloud Stream functional model with a `Function` bean named `transform`.
 
 To run:
 
 ```bash
 % cd demo
+% ../mvnw -f ../pom.xml -pl nats-spring-cloud-stream-binder -am -DskipTests -Dgpg.skip install
 % ../mvnw clean package
 % java -jar target/demo-0.0.1-SNAPSHOT.jar
 ```

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.14</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.nats</groupId>
@@ -16,7 +16,18 @@
 
     <properties>
         <java.version>17</java.version>
+        <spring-cloud-stream.version>4.2.1</spring-cloud-stream.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-stream</artifactId>
+                <version>${spring-cloud-stream.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -58,41 +69,13 @@
 
     <repositories>
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-snapshots</id>
+            <name>Central Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
         </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-        </pluginRepository>
-    </pluginRepositories>
 
 </project>

--- a/demo/src/main/java/io/nats/demo/ReverseProcessor.java
+++ b/demo/src/main/java/io/nats/demo/ReverseProcessor.java
@@ -1,32 +1,33 @@
 package io.nats.demo;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.function.Function;
 
-import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.cloud.stream.messaging.Processor;
-import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
 
-@EnableBinding(Processor.class)
+@Component
 public class ReverseProcessor {
-    @StreamListener(Processor.INPUT)
-    @SendTo(Processor.OUTPUT)
-    public Object transform(Object message) {
-        if (message instanceof byte[]) {
-            String value = new String((byte[]) message, StandardCharsets.UTF_8);
-            StringBuilder reverse = new StringBuilder();
-            for (int i = value.length() - 1; i >= 0; i--) {
-                reverse.append(value.charAt(i));
+
+    @Bean
+    public Function<Object, Object> transform() {
+        return message -> {
+            if (message instanceof byte[]) {
+                String value = new String((byte[]) message, StandardCharsets.UTF_8);
+                return reverseUppercase(value).getBytes(StandardCharsets.UTF_8);
+            } else if (message instanceof String value) {
+                return reverseUppercase(value).getBytes(StandardCharsets.UTF_8);
             }
-            message = reverse.toString().toUpperCase().getBytes(StandardCharsets.UTF_8);
-        } else if (message instanceof String) {
-            String value = (String) message;
-            StringBuilder reverse = new StringBuilder();
-            for (int i = value.length() - 1; i >= 0; i--) {
-                reverse.append(value.charAt(i));
-            }
-            message = reverse.toString().toUpperCase().getBytes(StandardCharsets.UTF_8);
+            return message;
+        };
+    }
+
+    private static String reverseUppercase(String value) {
+        StringBuilder reverse = new StringBuilder();
+        for (int i = value.length() - 1; i >= 0; i--) {
+            reverse.append(value.charAt(i));
         }
-        return message;
+        return reverse.toString().toUpperCase(Locale.ROOT);
     }
 }

--- a/demo/src/main/resources/application.properties
+++ b/demo/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+spring.cloud.function.definition=transform
+spring.cloud.stream.function.bindings.transform-in-0=input
+spring.cloud.stream.function.bindings.transform-out-0=output
 spring.cloud.stream.bindings.input.destination=dataIn
 spring.cloud.stream.bindings.input.binder=nats
 spring.cloud.stream.bindings.output.destination=dataOut

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/FunctionalBinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/FunctionalBinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 @ResourceLock(Resources.SYSTEM_PROPERTIES)
 class FunctionalBinderTests {
-    private static final Duration FLUSH_TIMEOUT = Duration.ofSeconds(1);
+    private static final Duration FLUSH_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration RECEIVE_TIMEOUT = Duration.ofSeconds(5);
 
     @Test
@@ -86,6 +86,7 @@ class FunctionalBinderTests {
                  Connection connection = Nats.connect(server.getURI())) {
 
                 Subscription output = connection.subscribe(outputSubject);
+                connection.flush(FLUSH_TIMEOUT);
 
                 publishUntilOutput(connection, inputSubject, output, "functional function", "FUNCTIONAL FUNCTION");
             }
@@ -104,6 +105,7 @@ class FunctionalBinderTests {
                  Connection connection = Nats.connect(server.getURI())) {
 
                 Subscription output = connection.subscribe(subject);
+                connection.flush(FLUSH_TIMEOUT);
                 StreamBridge streamBridge = context.getBean(StreamBridge.class);
 
                 assertThat(streamBridge.send("bridgeOut",
@@ -115,12 +117,11 @@ class FunctionalBinderTests {
     }
 
     private static ConfigurableApplicationContext runApplication(Class<?> source, String server, String... properties) {
-        String[] arguments = new String[properties.length + 3];
-        arguments[0] = "--spring.main.web-application-type=none";
-        arguments[1] = "--spring.jmx.enabled=false";
-        arguments[2] = "--nats.spring.server=" + server;
+        String[] arguments = new String[properties.length + 2];
+        arguments[0] = "--spring.jmx.enabled=false";
+        arguments[1] = "--nats.spring.server=" + server;
         for (int index = 0; index < properties.length; index++) {
-            arguments[index + 3] = "--" + properties[index];
+            arguments[index + 2] = "--" + properties[index];
         }
 
         return new SpringApplicationBuilder(source)
@@ -158,20 +159,25 @@ class FunctionalBinderTests {
                                            String payload,
                                            String expected) throws Exception {
         long deadline = System.nanoTime() + RECEIVE_TIMEOUT.toNanos();
+        List<String> actualMessages = new ArrayList<>();
         while (System.nanoTime() < deadline) {
             connection.publish(subject, payload.getBytes(UTF_8));
             connection.flush(FLUSH_TIMEOUT);
             Message message = output.nextMessage(Duration.ofMillis(200));
             if (message != null) {
-                assertThat(new String(message.getData(), UTF_8)).isEqualTo(expected);
-                return;
+                String received = new String(message.getData(), UTF_8);
+                if (expected.equals(received)) {
+                    return;
+                }
+                actualMessages.add(received);
             }
         }
 
-        fail("Expected NATS subject <%s> to emit transformed payload <%s> after publishing <%s>",
+        fail("Expected NATS subject <%s> to emit transformed payload <%s> after publishing <%s>, but received <%s>",
                 subject,
                 expected,
-                payload);
+                payload,
+                actualMessages);
     }
 
     private static String nextText(Subscription subscription) throws InterruptedException {

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/FunctionalBinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/FunctionalBinderTests.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nats.cloud.stream.binder;
+
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import io.nats.client.Subscription;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.integration.support.MessageBuilder;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
+class FunctionalBinderTests {
+    private static final Duration FLUSH_TIMEOUT = Duration.ofSeconds(1);
+    private static final Duration RECEIVE_TIMEOUT = Duration.ofSeconds(5);
+
+    @Test
+    void functionalConsumerReceivesNatsMessagesForIssue29() throws Exception {
+        try (NatsBinderTestServer server = new NatsBinderTestServer()) {
+            String subject = uniqueSubject("functional.consumer.issue29");
+            try (ConfigurableApplicationContext context = runApplication(
+                    FunctionalConsumerApplication.class,
+                    server.getURI(),
+                    "spring.cloud.function.definition=input",
+                    "spring.cloud.stream.bindings.input-in-0.destination=" + subject,
+                    "spring.cloud.stream.bindings.input-in-0.binder=nats");
+                 Connection connection = Nats.connect(server.getURI())) {
+
+                BlockingQueue<String> receivedMessages = context.getBean("receivedMessages", BlockingQueue.class);
+
+                publishUntilReceived(connection, subject, "functional consumer", receivedMessages);
+            }
+        }
+    }
+
+    @Test
+    void functionalFunctionTransformsNatsMessagesForIssue29() throws Exception {
+        try (NatsBinderTestServer server = new NatsBinderTestServer()) {
+            String inputSubject = uniqueSubject("functional.function.input.issue29");
+            String outputSubject = uniqueSubject("functional.function.output.issue29");
+            try (ConfigurableApplicationContext ignored = runApplication(
+                    FunctionalFunctionApplication.class,
+                    server.getURI(),
+                    "spring.cloud.function.definition=transform",
+                    "spring.cloud.stream.bindings.transform-in-0.destination=" + inputSubject,
+                    "spring.cloud.stream.bindings.transform-in-0.binder=nats",
+                    "spring.cloud.stream.bindings.transform-out-0.destination=" + outputSubject,
+                    "spring.cloud.stream.bindings.transform-out-0.binder=nats");
+                 Connection connection = Nats.connect(server.getURI())) {
+
+                Subscription output = connection.subscribe(outputSubject);
+
+                publishUntilOutput(connection, inputSubject, output, "functional function", "FUNCTIONAL FUNCTION");
+            }
+        }
+    }
+
+    @Test
+    void streamBridgePublishesNatsMessagesForIssue29() throws Exception {
+        try (NatsBinderTestServer server = new NatsBinderTestServer()) {
+            String subject = uniqueSubject("functional.streambridge.issue29");
+            try (ConfigurableApplicationContext context = runApplication(
+                    StreamBridgeApplication.class,
+                    server.getURI(),
+                    "spring.cloud.stream.bindings.bridgeOut.destination=" + subject,
+                    "spring.cloud.stream.bindings.bridgeOut.binder=nats");
+                 Connection connection = Nats.connect(server.getURI())) {
+
+                Subscription output = connection.subscribe(subject);
+                StreamBridge streamBridge = context.getBean(StreamBridge.class);
+
+                assertThat(streamBridge.send("bridgeOut",
+                        MessageBuilder.withPayload("functional stream bridge".getBytes(UTF_8)).build())).isTrue();
+
+                assertThat(nextText(output)).isEqualTo("functional stream bridge");
+            }
+        }
+    }
+
+    private static ConfigurableApplicationContext runApplication(Class<?> source, String server, String... properties) {
+        String[] arguments = new String[properties.length + 3];
+        arguments[0] = "--spring.main.web-application-type=none";
+        arguments[1] = "--spring.jmx.enabled=false";
+        arguments[2] = "--nats.spring.server=" + server;
+        for (int index = 0; index < properties.length; index++) {
+            arguments[index + 3] = "--" + properties[index];
+        }
+
+        return new SpringApplicationBuilder(source)
+                .web(WebApplicationType.NONE)
+                .run(arguments);
+    }
+
+    private static void publishUntilReceived(Connection connection,
+                                             String subject,
+                                             String payload,
+                                             BlockingQueue<String> receivedMessages) throws Exception {
+        long deadline = System.nanoTime() + RECEIVE_TIMEOUT.toNanos();
+        List<String> actualMessages = new ArrayList<>();
+        while (System.nanoTime() < deadline) {
+            connection.publish(subject, payload.getBytes(UTF_8));
+            connection.flush(FLUSH_TIMEOUT);
+            String received = receivedMessages.poll(200, TimeUnit.MILLISECONDS);
+            if (payload.equals(received)) {
+                return;
+            }
+            if (received != null) {
+                actualMessages.add(received);
+            }
+        }
+
+        fail("Expected NATS subject <%s> to deliver <%s>, but received <%s>",
+                subject,
+                payload,
+                actualMessages);
+    }
+
+    private static void publishUntilOutput(Connection connection,
+                                           String subject,
+                                           Subscription output,
+                                           String payload,
+                                           String expected) throws Exception {
+        long deadline = System.nanoTime() + RECEIVE_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            connection.publish(subject, payload.getBytes(UTF_8));
+            connection.flush(FLUSH_TIMEOUT);
+            Message message = output.nextMessage(Duration.ofMillis(200));
+            if (message != null) {
+                assertThat(new String(message.getData(), UTF_8)).isEqualTo(expected);
+                return;
+            }
+        }
+
+        fail("Expected NATS subject <%s> to emit transformed payload <%s> after publishing <%s>",
+                subject,
+                expected,
+                payload);
+    }
+
+    private static String nextText(Subscription subscription) throws InterruptedException {
+        Message message = subscription.nextMessage(RECEIVE_TIMEOUT);
+        assertThat(message).isNotNull();
+        return new String(message.getData(), UTF_8);
+    }
+
+    private static String uniqueSubject(String prefix) {
+        return prefix + "." + System.nanoTime();
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class FunctionalConsumerApplication {
+        @Bean
+        BlockingQueue<String> receivedMessages() {
+            return new LinkedBlockingQueue<>();
+        }
+
+        @Bean
+        Consumer<byte[]> input(BlockingQueue<String> receivedMessages) {
+            return payload -> receivedMessages.add(new String(payload, UTF_8));
+        }
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class FunctionalFunctionApplication {
+        @Bean
+        Function<byte[], byte[]> transform() {
+            return payload -> new String(payload, UTF_8)
+                    .toUpperCase(Locale.ROOT)
+                    .getBytes(UTF_8);
+        }
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class StreamBridgeApplication {
+    }
+}

--- a/nats-spring-samples/connect-error-sample/src/main/resources/application.properties
+++ b/nats-spring-samples/connect-error-sample/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.cloud.stream.bindings.input-in-0.destination=dataIn
-spring.cloud.stream.bindings.input.in-0.binder=nats
+spring.cloud.stream.bindings.input-in-0.binder=nats
 nats.spring.server=nats://localhost:4222


### PR DESCRIPTION
## Summary
- migrate the standalone demo from removed Spring Cloud Stream annotations to the functional model
- add real NATS E2E coverage for Consumer, Function, and StreamBridge bindings
- fix the connect-error sample binding typo and refresh demo snapshot repository/docs

Fixes #29.

## Verification
- mvn -pl nats-spring-cloud-stream-binder -Dtest=FunctionalBinderTests test
- mvn -pl nats-spring-cloud-stream-binder test
- mvn -pl nats-spring-cloud-stream-binder -am -DskipTests -Dgpg.skip install
- mvn -f demo/pom.xml test
- git diff --check