### PR TITLE
refactor: simplify JetStream consumer binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,15 +154,13 @@ Spring Cloud Stream functional applications are supported. Bind `Consumer`, `Fun
 
 The NATS binder leverages the autoconfigure module, or manual configuration to build a NATS connection. Standard properties are used to specify inputs and outputs. Inputs, specified with a destination and group name are mapped to subjects and queue names, with the destination becoming the subject, and the group becoming the queue. Outputs are specified with a destination name that becomes the subject.
 
-Consumers are implemented with a dispatcher. Each consumer will create its own dispatcher in the core library, resulting in a thread per consumer.
-
-Polled consumers are implemented with a subscription. Core NATS polled consumers wait forever for a message; JetStream polled consumers use a configurable fetch timeout.
+Core NATS event consumers are implemented with a dispatcher, resulting in a thread per consumer. JetStream event consumers use a named JetStream consumer context. Polled consumers use a subscription for core NATS and a named JetStream consumer context for JetStream.
 
 Producers publish directly through the connection.
 
 ### JetStream <a name="jetstream"></a>
 
-JetStream is opt-in per binding. The NATS stream must already exist unless `provision-stream=true` is set. `stream-name` is optional for normal publish/subscribe operations when NATS can resolve one stream from the subject, but it is required for stream provisioning.
+JetStream is opt-in per binding. Producer stream provisioning is optional with `provision-stream=true`; consumer streams and consumers should be created with NATS or the jnats `ConsumerConfiguration` API before the binder starts. JetStream consumers require `stream-name` and either `consumer-name` or a binding group. The binding group is used as the JetStream consumer name when `consumer-name` is not set.
 
 ```properties
 nats.spring.cloud.stream.bindings.output.producer.jet-stream=true
@@ -172,17 +170,12 @@ nats.spring.cloud.stream.bindings.output.producer.stream-storage-type=memory
 nats.spring.cloud.stream.bindings.output.producer.stream-replicas=1
 nats.spring.cloud.stream.bindings.input.consumer.jet-stream=true
 nats.spring.cloud.stream.bindings.input.consumer.stream-name=ORDERS
-nats.spring.cloud.stream.bindings.input.consumer.durable-name=orders-worker
-nats.spring.cloud.stream.bindings.input.consumer.ack-wait=30s
-nats.spring.cloud.stream.bindings.input.consumer.max-deliver=5
-nats.spring.cloud.stream.bindings.input.consumer.max-ack-pending=100
+nats.spring.cloud.stream.bindings.input.consumer.consumer-name=orders-worker
 ```
 
-When provisioning is enabled, the binder creates a missing stream for the binding destination subject. If the stream already exists, it must already cover the destination subject directly or through a NATS wildcard subject. `stream-storage-type` and `stream-replicas` are used only when creating a missing stream.
+When producer provisioning is enabled, the binder creates a missing stream for the binding destination subject. If the stream already exists, it must already cover the destination subject directly or through a NATS wildcard subject. `stream-storage-type` and `stream-replicas` are used only when creating a missing stream.
 
-JetStream producers wait for the server publish acknowledgement. Event consumers acknowledge after the Spring output channel accepts the message and negatively acknowledge when the output channel rejects the message. Polled consumers use a pull subscription and acknowledge through Spring's poll acknowledgement callback: successful polls acknowledge and rejected polls negatively acknowledge for redelivery. For polled consumers, the binding group is used as the JetStream durable name when `durable-name` is not set.
-
-JetStream consumers can also configure delivery behavior with `deliver-policy`, `replay-policy`, `ack-wait`, `max-deliver`, `max-ack-pending`, and `inactive-threshold`. Push consumers additionally support `ordered`, `flow-control`, and `idle-heartbeat`; `flow-control` requires `idle-heartbeat`, and both are only valid without a consumer group. Ordered push consumers cannot use `durable-name` or a consumer group, and `max-deliver` must be unset or `1`. Polled consumers additionally support `poll-timeout`, `max-pull-waiting`, `max-batch`, and `max-bytes`.
+JetStream producers wait for the server publish acknowledgement. Event consumers acknowledge after the Spring output channel accepts the message and negatively acknowledge when the output channel rejects the message. Polled consumers use the jnats consumer context and acknowledge through Spring's poll acknowledgement callback: successful polls acknowledge and rejected polls negatively acknowledge for redelivery.
 
 JetStream publishing does not support Spring reply channels because NATS uses the reply subject for JetStream publish acknowledgements. Use core NATS bindings for request-reply.
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ When producer provisioning is enabled, the binder creates a missing stream for t
 
 JetStream producers wait for the server publish acknowledgement. Event consumers acknowledge after the Spring output channel accepts the message and negatively acknowledge when the output channel rejects the message. Polled consumers use the jnats consumer context and acknowledge through Spring's poll acknowledgement callback: successful polls acknowledge and rejected polls negatively acknowledge for redelivery.
 
+Consumer delivery settings such as acknowledgement wait, maximum deliveries, flow control, replay policy, and pull limits are configured on the JetStream consumer itself. Applications that previously configured those settings as binder consumer properties should create or update the JetStream consumer before the binding starts and set `consumer-name` to that consumer name.
+
 JetStream publishing does not support Spring reply channels because NATS uses the reply subject for JetStream publish acknowledgements. Use core NATS bindings for request-reply.
 
 ### Request-Reply <a name="reqreply"></a>

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
@@ -162,7 +162,6 @@ public class NatsChannelBinder extends
                                                      ExtendedConsumerProperties<NatsConsumerProperties> properties) {
         NatsConsumerProperties extension = consumerExtension(properties);
         NatsConsumerDestination consumerDestination = (NatsConsumerDestination) destination;
-        NatsJetStreamSupport.provisionStream(this.connection, consumerDestination.getSubject(), extension);
         return new NatsMessageProducer(
                 consumerDestination,
                 this.connection,
@@ -170,8 +169,7 @@ public class NatsChannelBinder extends
                 shouldMarkNativeHeadersPresent(properties),
                 isJetStream(extension),
                 streamName(extension),
-                durableName(extension),
-                extension);
+                consumerName(extension));
     }
 
     @Override
@@ -179,7 +177,6 @@ public class NatsChannelBinder extends
                                                                     ConsumerDestination destination, ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties) {
         NatsConsumerProperties extension = consumerExtension(consumerProperties);
         NatsConsumerDestination consumerDestination = (NatsConsumerDestination) destination;
-        NatsJetStreamSupport.provisionStream(this.connection, consumerDestination.getSubject(), extension);
         return new PolledConsumerResources(
                 new NatsMessageSource(
                         consumerDestination,
@@ -188,8 +185,7 @@ public class NatsChannelBinder extends
                         shouldMarkNativeHeadersPresent(consumerProperties),
                         isJetStream(extension),
                         streamName(extension),
-                        durableName(extension),
-                        extension),
+                        consumerName(extension)),
                 registerErrorInfrastructure(destination, group, consumerProperties, true));
     }
 
@@ -217,8 +213,8 @@ public class NatsChannelBinder extends
         return properties == null ? null : properties.getStreamName();
     }
 
-    private static String durableName(NatsConsumerProperties properties) {
-        return properties == null ? null : properties.getDurableName();
+    private static String consumerName(NatsConsumerProperties properties) {
+        return properties == null ? null : properties.getConsumerName();
     }
 
     private static boolean shouldUseNativeHeaders(ExtendedProducerProperties<NatsProducerProperties> producerProperties) {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsJetStreamSupport.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsJetStreamSupport.java
@@ -19,11 +19,9 @@ package io.nats.cloud.stream.binder;
 import io.nats.client.Connection;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.JetStreamManagement;
-import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
-import io.nats.cloud.stream.binder.properties.NatsConsumerProperties;
 import io.nats.cloud.stream.binder.properties.NatsProducerProperties;
 
 import java.io.IOException;
@@ -31,7 +29,7 @@ import java.time.Duration;
 import java.util.List;
 
 class NatsJetStreamSupport {
-    static final Duration DEFAULT_JETSTREAM_POLL_TIMEOUT = Duration.ofMillis(50);
+    static final Duration DEFAULT_JETSTREAM_POLL_TIMEOUT = Duration.ofSeconds(1);
 
     private static final int HTTP_NOT_FOUND = 404;
     private static final int STREAM_NOT_FOUND = 10059;
@@ -51,120 +49,7 @@ class NatsJetStreamSupport {
         return value != null && value.trim().length() > 0;
     }
 
-    static Duration pollTimeout(NatsConsumerProperties properties) {
-        if (properties == null || properties.getPollTimeout() == null) {
-            return DEFAULT_JETSTREAM_POLL_TIMEOUT;
-        }
-
-        Duration pollTimeout = properties.getPollTimeout();
-        if (pollTimeout.isZero() || pollTimeout.isNegative()) {
-            throw new IllegalArgumentException("NATS JetStream poll-timeout must be greater than zero");
-        }
-
-        return pollTimeout;
-    }
-
-    static ConsumerConfiguration consumerConfiguration(NatsConsumerProperties properties, boolean pullConsumer) {
-        if (properties == null) {
-            return null;
-        }
-
-        ConsumerConfiguration.Builder builder = ConsumerConfiguration.builder();
-        boolean configured = false;
-
-        if (properties.getDeliverPolicy() != null) {
-            builder.deliverPolicy(properties.getDeliverPolicy());
-            configured = true;
-        }
-        if (properties.getReplayPolicy() != null) {
-            builder.replayPolicy(properties.getReplayPolicy());
-            configured = true;
-        }
-        if (properties.getAckWait() != null) {
-            builder.ackWait(properties.getAckWait());
-            configured = true;
-        }
-        if (properties.getMaxDeliver() != null) {
-            builder.maxDeliver(properties.getMaxDeliver());
-            configured = true;
-        }
-        if (properties.getMaxAckPending() != null) {
-            builder.maxAckPending(properties.getMaxAckPending());
-            configured = true;
-        }
-        if (!pullConsumer) {
-            if (Boolean.TRUE.equals(properties.getFlowControl())) {
-                builder.flowControl(properties.getIdleHeartbeat());
-                configured = true;
-            } else if (properties.getIdleHeartbeat() != null) {
-                builder.idleHeartbeat(properties.getIdleHeartbeat());
-                configured = true;
-            }
-        }
-        if (properties.getInactiveThreshold() != null) {
-            builder.inactiveThreshold(properties.getInactiveThreshold());
-            configured = true;
-        }
-        if (pullConsumer) {
-            if (properties.getMaxPullWaiting() != null) {
-                builder.maxPullWaiting(properties.getMaxPullWaiting());
-                configured = true;
-            }
-            if (properties.getMaxBatch() != null) {
-                builder.maxBatch(properties.getMaxBatch());
-                configured = true;
-            }
-            if (properties.getMaxBytes() != null) {
-                builder.maxBytes(properties.getMaxBytes());
-                configured = true;
-            }
-        }
-
-        return configured ? builder.build() : null;
-    }
-
-    static void validatePushConsumer(NatsConsumerProperties properties, String queue, String durableName) {
-        if (properties == null) {
-            return;
-        }
-
-        String group = normalize(queue);
-        if (hasText(group) && (Boolean.TRUE.equals(properties.getFlowControl()) || properties.getIdleHeartbeat() != null)) {
-            throw new IllegalArgumentException(
-                    "NATS JetStream push consumer flow-control and idle-heartbeat are not supported with consumer groups");
-        }
-        if (Boolean.TRUE.equals(properties.getFlowControl()) && properties.getIdleHeartbeat() == null) {
-            throw new IllegalArgumentException("NATS JetStream flow-control requires idle-heartbeat");
-        }
-
-        if (!Boolean.TRUE.equals(properties.getOrdered())) {
-            return;
-        }
-
-        if (hasText(durableName)) {
-            throw new IllegalArgumentException("NATS JetStream ordered consumers cannot use durable-name");
-        }
-        if (hasText(group)) {
-            throw new IllegalArgumentException("NATS JetStream ordered consumers cannot use consumer groups");
-        }
-        if (properties.getMaxDeliver() != null && properties.getMaxDeliver() > 1) {
-            throw new IllegalArgumentException("NATS JetStream ordered consumers require max-deliver to be unset or 1");
-        }
-    }
-
     static void provisionStream(Connection connection, String subject, NatsProducerProperties properties) {
-        if (properties == null || !properties.isJetStream() || !properties.isProvisionStream()) {
-            return;
-        }
-
-        provisionStream(connection,
-                subject,
-                properties.getStreamName(),
-                properties.getStreamStorageType(),
-                properties.getStreamReplicas());
-    }
-
-    static void provisionStream(Connection connection, String subject, NatsConsumerProperties properties) {
         if (properties == null || !properties.isJetStream() || !properties.isProvisionStream()) {
             return;
         }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageHandler.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageHandler.java
@@ -138,9 +138,6 @@ public class NatsMessageHandler extends AbstractMessageHandler {
 
         try {
             JetStream js = this.jetStreamContext;
-            if (js == null) {
-                throw new MessageHandlingException(message, "NATS JetStream context is not available");
-            }
             PublishOptions publishOptions = publishOptions();
             if (headers == null) {
                 if (publishOptions == null) {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
@@ -30,6 +30,7 @@ import org.springframework.messaging.support.GenericMessage;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * MessageProducer for NATS connections.
@@ -45,8 +46,8 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
     private NatsConsumerDestination destination;
     private Connection connection;
     private MessageChannel output;
-    private Dispatcher dispatcher;
-    private io.nats.client.MessageConsumer jetStreamConsumer;
+    private AtomicReference<Dispatcher> dispatcher = new AtomicReference<>();
+    private AtomicReference<io.nats.client.MessageConsumer> jetStreamConsumer = new AtomicReference<>();
     private boolean includeNativeHeaders;
     private boolean markNativeHeadersPresent;
     private boolean jetStream;
@@ -112,12 +113,12 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
 
     @Override
     public boolean isRunning() {
-        return this.dispatcher != null;
+        return this.dispatcher.get() != null;
     }
 
     @Override
     public void start() {
-        if (this.dispatcher != null) {
+        if (this.dispatcher.get() != null) {
             return;
         }
 
@@ -126,15 +127,16 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
             return;
         }
 
-        this.dispatcher = this.connection.createDispatcher(this::handleIncomingMessage);
+        Dispatcher dispatcher = this.connection.createDispatcher(this::handleIncomingMessage);
+        this.dispatcher.set(dispatcher);
 
         String sub = this.destination.getSubject();
         String queue = this.destination.getQueueGroup();
 
         if (queue != null && queue.length() > 0) {
-            this.dispatcher.subscribe(sub, queue);
+            dispatcher.subscribe(sub, queue);
         } else {
-            this.dispatcher.subscribe(sub);
+            dispatcher.subscribe(sub);
         }
     }
 
@@ -152,15 +154,16 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
             throw new IllegalStateException("NATS JetStream consumers require consumer-name or a consumer group");
         }
 
-        this.dispatcher = this.connection.createDispatcher();
+        Dispatcher dispatcher = this.connection.createDispatcher();
+        this.dispatcher.set(dispatcher);
 
         try {
             ConsumerContext consumerContext = this.connection.jetStream()
                     .getConsumerContext(this.streamName, consumer);
-            this.jetStreamConsumer = consumerContext.consume(this.dispatcher, this::handleIncomingMessage);
+            this.jetStreamConsumer.set(consumerContext.consume(dispatcher, this::handleIncomingMessage));
         } catch (IOException | JetStreamApiException | IllegalArgumentException exp) {
-            this.connection.closeDispatcher(this.dispatcher);
-            this.dispatcher = null;
+            this.connection.closeDispatcher(dispatcher);
+            this.dispatcher.compareAndSet(dispatcher, null);
             throw new IllegalStateException("Failed to subscribe to NATS JetStream subject " + sub, exp);
         }
     }
@@ -197,15 +200,15 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
 
     @Override
     public void stop() {
-        if (this.dispatcher == null) {
+        Dispatcher dispatcher = this.dispatcher.getAndSet(null);
+        if (dispatcher == null) {
             return;
         }
 
-        if (this.jetStreamConsumer != null) {
-            this.jetStreamConsumer.stop();
-            this.jetStreamConsumer = null;
+        io.nats.client.MessageConsumer consumer = this.jetStreamConsumer.getAndSet(null);
+        if (consumer != null) {
+            consumer.stop();
         }
-        this.connection.closeDispatcher(this.dispatcher);
-        this.dispatcher = null;
+        this.connection.closeDispatcher(dispatcher);
     }
 }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
@@ -17,13 +17,10 @@
 package io.nats.cloud.stream.binder;
 
 import io.nats.client.Connection;
+import io.nats.client.ConsumerContext;
 import io.nats.client.Dispatcher;
-import io.nats.client.JetStream;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.Message;
-import io.nats.client.PushSubscribeOptions;
-import io.nats.client.api.ConsumerConfiguration;
-import io.nats.cloud.stream.binder.properties.NatsConsumerProperties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.Lifecycle;
@@ -49,12 +46,12 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
     private Connection connection;
     private MessageChannel output;
     private Dispatcher dispatcher;
+    private io.nats.client.MessageConsumer jetStreamConsumer;
     private boolean includeNativeHeaders;
     private boolean markNativeHeadersPresent;
     private boolean jetStream;
     private String streamName;
-    private String durableName;
-    private NatsConsumerProperties consumerProperties;
+    private String consumerName;
 
     /**
      * Create a message producer. Once started the producer will use a dispatcher, and the associated thread, to
@@ -89,38 +86,18 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
      * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
      * @param jetStream                whether messages should be consumed through JetStream
      * @param streamName               optional JetStream stream name
-     * @param durableName              optional JetStream durable consumer name
+     * @param consumerName             optional JetStream consumer name
      */
     public NatsMessageProducer(NatsConsumerDestination destination, Connection nc,
                                boolean includeNativeHeaders, boolean markNativeHeadersPresent,
-                               boolean jetStream, String streamName, String durableName) {
-        this(destination, nc, includeNativeHeaders, markNativeHeadersPresent, jetStream, streamName, durableName, null);
-    }
-
-    /**
-     * Create a message producer with explicit native header and JetStream behavior.
-     *
-     * @param destination              where to subscribe
-     * @param nc                       NATS connection
-     * @param includeNativeHeaders     whether native NATS headers should be copied to Spring headers
-     * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
-     * @param jetStream                whether messages should be consumed through JetStream
-     * @param streamName               optional JetStream stream name
-     * @param durableName              optional JetStream durable consumer name
-     * @param consumerProperties       optional JetStream consumer configuration properties
-     */
-    public NatsMessageProducer(NatsConsumerDestination destination, Connection nc,
-                               boolean includeNativeHeaders, boolean markNativeHeadersPresent,
-                               boolean jetStream, String streamName, String durableName,
-                               NatsConsumerProperties consumerProperties) {
+                               boolean jetStream, String streamName, String consumerName) {
         this.destination = destination;
         this.connection = nc;
         this.includeNativeHeaders = includeNativeHeaders;
         this.markNativeHeadersPresent = markNativeHeadersPresent;
         this.jetStream = jetStream;
         this.streamName = NatsJetStreamSupport.normalize(streamName);
-        this.durableName = NatsJetStreamSupport.normalize(durableName);
-        this.consumerProperties = consumerProperties;
+        this.consumerName = NatsJetStreamSupport.normalize(consumerName);
     }
 
     @Override
@@ -164,18 +141,23 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
     private void startJetStream() {
         String sub = this.destination.getSubject();
         String queue = this.destination.getQueueGroup();
-        NatsJetStreamSupport.validatePushConsumer(this.consumerProperties, queue, this.durableName);
+        String consumer = NatsJetStreamSupport.hasText(this.consumerName)
+                ? this.consumerName
+                : NatsJetStreamSupport.normalize(queue);
+
+        if (!NatsJetStreamSupport.hasText(this.streamName)) {
+            throw new IllegalStateException("NATS JetStream consumers require stream-name");
+        }
+        if (!NatsJetStreamSupport.hasText(consumer)) {
+            throw new IllegalStateException("NATS JetStream consumers require consumer-name or a consumer group");
+        }
 
         this.dispatcher = this.connection.createDispatcher();
 
         try {
-            JetStream js = this.connection.jetStream();
-            PushSubscribeOptions options = pushSubscribeOptions();
-            if (queue != null && queue.length() > 0) {
-                js.subscribe(sub, queue, this.dispatcher, this::handleIncomingMessage, false, options);
-            } else {
-                js.subscribe(sub, this.dispatcher, this::handleIncomingMessage, false, options);
-            }
+            ConsumerContext consumerContext = this.connection.jetStream()
+                    .getConsumerContext(this.streamName, consumer);
+            this.jetStreamConsumer = consumerContext.consume(this.dispatcher, this::handleIncomingMessage);
         } catch (IOException | JetStreamApiException | IllegalArgumentException exp) {
             this.connection.closeDispatcher(this.dispatcher);
             this.dispatcher = null;
@@ -219,25 +201,11 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
             return;
         }
 
+        if (this.jetStreamConsumer != null) {
+            this.jetStreamConsumer.stop();
+            this.jetStreamConsumer = null;
+        }
         this.connection.closeDispatcher(this.dispatcher);
         this.dispatcher = null;
-    }
-
-    private PushSubscribeOptions pushSubscribeOptions() {
-        PushSubscribeOptions.Builder builder = PushSubscribeOptions.builder();
-        if (NatsJetStreamSupport.hasText(this.streamName)) {
-            builder.stream(this.streamName);
-        }
-        if (NatsJetStreamSupport.hasText(this.durableName)) {
-            builder.durable(this.durableName);
-        }
-        ConsumerConfiguration consumerConfiguration = NatsJetStreamSupport.consumerConfiguration(this.consumerProperties, false);
-        if (consumerConfiguration != null) {
-            builder.configuration(consumerConfiguration);
-        }
-        if (this.consumerProperties != null && Boolean.TRUE.equals(this.consumerProperties.getOrdered())) {
-            builder.ordered(true);
-        }
-        return builder.build();
     }
 }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
@@ -17,14 +17,11 @@
 package io.nats.cloud.stream.binder;
 
 import io.nats.client.Connection;
-import io.nats.client.JetStream;
+import io.nats.client.ConsumerContext;
 import io.nats.client.JetStreamApiException;
-import io.nats.client.JetStreamSubscription;
+import io.nats.client.JetStreamStatusCheckedException;
 import io.nats.client.Message;
-import io.nats.client.PullSubscribeOptions;
 import io.nats.client.Subscription;
-import io.nats.client.api.ConsumerConfiguration;
-import io.nats.cloud.stream.binder.properties.NatsConsumerProperties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.Lifecycle;
@@ -35,7 +32,6 @@ import org.springframework.messaging.support.GenericMessage;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -48,18 +44,17 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     private NatsConsumerDestination destination;
     private Connection connection;
     private Subscription sub;
+    private ConsumerContext consumerContext;
     private boolean includeNativeHeaders;
     private boolean markNativeHeadersPresent;
     private boolean jetStream;
     private String streamName;
-    private String durableName;
-    private NatsConsumerProperties consumerProperties;
-    private Duration jetStreamPollTimeout;
+    private String consumerName;
 
     /**
      * Create a message source. Once started, the source will have a subscription but no threads.
-     * Calls to doReceive result in a nextMessage call at the NATS level. Currently nextMessage is
-     * called with Duration.ZERO for core NATS and a short timeout for JetStream pull subscriptions.
+     * Calls to doReceive result in a nextMessage call at the NATS level. Core NATS uses a
+     * subscription, while JetStream uses a named ConsumerContext.
      *
      * @param destination where to subscribe
      * @param nc          NATS connection
@@ -90,59 +85,35 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
      * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
      * @param jetStream                whether messages should be consumed through JetStream
      * @param streamName               optional JetStream stream name
-     * @param durableName              optional JetStream durable consumer name
+     * @param consumerName             optional JetStream consumer name
      */
     public NatsMessageSource(NatsConsumerDestination destination, Connection nc,
                              boolean includeNativeHeaders, boolean markNativeHeadersPresent,
-                             boolean jetStream, String streamName, String durableName) {
-        this(destination, nc, includeNativeHeaders, markNativeHeadersPresent, jetStream, streamName, durableName, null);
-    }
-
-    /**
-     * Create a message source with explicit native header and JetStream behavior.
-     *
-     * @param destination              where to subscribe
-     * @param nc                       NATS connection
-     * @param includeNativeHeaders     whether native NATS headers should be copied to Spring headers
-     * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
-     * @param jetStream                whether messages should be consumed through JetStream
-     * @param streamName               optional JetStream stream name
-     * @param durableName              optional JetStream durable consumer name
-     * @param consumerProperties       optional JetStream consumer configuration properties
-     */
-    public NatsMessageSource(NatsConsumerDestination destination, Connection nc,
-                             boolean includeNativeHeaders, boolean markNativeHeadersPresent,
-                             boolean jetStream, String streamName, String durableName,
-                             NatsConsumerProperties consumerProperties) {
+                             boolean jetStream, String streamName, String consumerName) {
         this.destination = destination;
         this.connection = nc;
         this.includeNativeHeaders = includeNativeHeaders;
         this.markNativeHeadersPresent = markNativeHeadersPresent;
         this.jetStream = jetStream;
         this.streamName = NatsJetStreamSupport.normalize(streamName);
-        this.durableName = NatsJetStreamSupport.normalize(durableName);
-        this.consumerProperties = consumerProperties;
-        this.jetStreamPollTimeout = NatsJetStreamSupport.pollTimeout(consumerProperties);
+        this.consumerName = NatsJetStreamSupport.normalize(consumerName);
     }
 
     @Override
     protected Object doReceive() {
-        Subscription current = this.sub;
-        if (current == null) {
+        if (!this.jetStream && this.sub == null) {
+            return null;
+        }
+        if (this.jetStream && this.consumerContext == null) {
             return null;
         }
 
         try {
             Message m;
             if (this.jetStream) {
-                if (!(current instanceof JetStreamSubscription)) {
-                    throw new IllegalStateException("Expected JetStreamSubscription but got " + current.getClass());
-                }
-                JetStreamSubscription jetStreamSub = (JetStreamSubscription) current;
-                List<Message> messages = jetStreamSub.fetch(1, this.jetStreamPollTimeout);
-                m = messages.isEmpty() ? null : messages.get(0);
+                m = this.consumerContext.next(NatsJetStreamSupport.DEFAULT_JETSTREAM_POLL_TIMEOUT);
             } else {
-                m = current.nextMessage(Duration.ZERO);
+                m = this.sub.nextMessage(Duration.ZERO);
             }
 
             if (m != null && !m.isStatusMessage()) {
@@ -158,6 +129,8 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
             }
         } catch (InterruptedException exp) {
             logger.info("wait for message interrupted");
+        } catch (IOException | JetStreamApiException | JetStreamStatusCheckedException exp) {
+            logger.warn("exception receiving JetStream message", exp);
         }
 
         return null;
@@ -165,12 +138,12 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
 
     @Override
     public boolean isRunning() {
-        return this.sub != null;
+        return this.jetStream ? this.consumerContext != null : this.sub != null;
     }
 
     @Override
     public void start() {
-        if (this.sub != null) {
+        if (isRunning()) {
             return;
         }
 
@@ -190,9 +163,18 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     }
 
     private void startJetStream(String sub, String queue) {
+        String consumer = NatsJetStreamSupport.hasText(this.consumerName)
+                ? this.consumerName
+                : NatsJetStreamSupport.normalize(queue);
+        if (!NatsJetStreamSupport.hasText(this.streamName)) {
+            throw new IllegalStateException("NATS JetStream polled consumers require stream-name");
+        }
+        if (!NatsJetStreamSupport.hasText(consumer)) {
+            throw new IllegalStateException("NATS JetStream polled consumers require consumer-name or a consumer group");
+        }
+
         try {
-            JetStream js = this.connection.jetStream();
-            this.sub = js.subscribe(sub, pullSubscribeOptions(queue));
+            this.consumerContext = this.connection.jetStream().getConsumerContext(this.streamName, consumer);
         } catch (IOException | JetStreamApiException | IllegalArgumentException exp) {
             throw new IllegalStateException("Failed to subscribe to NATS JetStream subject " + sub, exp);
         }
@@ -200,6 +182,11 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
 
     @Override
     public void stop() {
+        if (this.jetStream) {
+            this.consumerContext = null;
+            return;
+        }
+
         if (this.sub == null) {
             return;
         }
@@ -211,24 +198,6 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     @Override
     public String getComponentType() {
         return "nats:message-source";
-    }
-
-    private PullSubscribeOptions pullSubscribeOptions(String queue) {
-        PullSubscribeOptions.Builder builder = PullSubscribeOptions.builder();
-        if (NatsJetStreamSupport.hasText(this.streamName)) {
-            builder.stream(this.streamName);
-        }
-        String durable = NatsJetStreamSupport.hasText(this.durableName)
-                ? this.durableName
-                : NatsJetStreamSupport.normalize(queue);
-        if (NatsJetStreamSupport.hasText(durable)) {
-            builder.durable(durable);
-        }
-        ConsumerConfiguration consumerConfiguration = NatsJetStreamSupport.consumerConfiguration(this.consumerProperties, true);
-        if (consumerConfiguration != null) {
-            builder.configuration(consumerConfiguration);
-        }
-        return builder.build();
     }
 
     private static class JetStreamAcknowledgmentCallback implements AcknowledgmentCallback {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
@@ -18,6 +18,8 @@ package io.nats.cloud.stream.binder;
 
 import io.nats.client.Connection;
 import io.nats.client.ConsumerContext;
+import io.nats.client.FetchConsumeOptions;
+import io.nats.client.FetchConsumer;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.JetStreamStatusCheckedException;
 import io.nats.client.Message;
@@ -34,6 +36,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Message source for NATS connections, allowing synchronous polling.
@@ -44,7 +47,8 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     private NatsConsumerDestination destination;
     private Connection connection;
     private Subscription sub;
-    private ConsumerContext consumerContext;
+    private AtomicReference<ConsumerContext> consumerContext = new AtomicReference<>();
+    private AtomicReference<FetchConsumer> fetchConsumer = new AtomicReference<>();
     private boolean includeNativeHeaders;
     private boolean markNativeHeadersPresent;
     private boolean jetStream;
@@ -101,19 +105,24 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
 
     @Override
     protected Object doReceive() {
+        ConsumerContext context = this.consumerContext.get();
         if (!this.jetStream && this.sub == null) {
             return null;
         }
-        if (this.jetStream && this.consumerContext == null) {
+        if (this.jetStream && context == null) {
             return null;
         }
 
         try {
             Message m;
             if (this.jetStream) {
-                m = this.consumerContext.next(NatsJetStreamSupport.DEFAULT_JETSTREAM_POLL_TIMEOUT);
+                m = receiveJetStreamMessage(context);
             } else {
                 m = this.sub.nextMessage(Duration.ZERO);
+            }
+
+            if (this.jetStream && this.consumerContext.get() != context) {
+                return null;
             }
 
             if (m != null && !m.isStatusMessage()) {
@@ -128,6 +137,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
                 return new GenericMessage<>(m.getData(), headers);
             }
         } catch (InterruptedException exp) {
+            Thread.currentThread().interrupt();
             logger.info("wait for message interrupted");
         } catch (IOException | JetStreamApiException | JetStreamStatusCheckedException exp) {
             logger.warn("exception receiving JetStream message", exp);
@@ -138,7 +148,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
 
     @Override
     public boolean isRunning() {
-        return this.jetStream ? this.consumerContext != null : this.sub != null;
+        return this.jetStream ? this.consumerContext.get() != null : this.sub != null;
     }
 
     @Override
@@ -174,7 +184,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
         }
 
         try {
-            this.consumerContext = this.connection.jetStream().getConsumerContext(this.streamName, consumer);
+            this.consumerContext.set(this.connection.jetStream().getConsumerContext(this.streamName, consumer));
         } catch (IOException | JetStreamApiException | IllegalArgumentException exp) {
             throw new IllegalStateException("Failed to subscribe to NATS JetStream subject " + sub, exp);
         }
@@ -183,7 +193,8 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     @Override
     public void stop() {
         if (this.jetStream) {
-            this.consumerContext = null;
+            this.consumerContext.set(null);
+            closeFetchConsumer(this.fetchConsumer.getAndSet(null));
             return;
         }
 
@@ -198,6 +209,35 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     @Override
     public String getComponentType() {
         return "nats:message-source";
+    }
+
+    private Message receiveJetStreamMessage(ConsumerContext context)
+            throws IOException, JetStreamApiException, InterruptedException, JetStreamStatusCheckedException {
+        FetchConsumer consumer = context.fetch(FetchConsumeOptions.builder()
+                .maxMessages(1)
+                .expiresIn(NatsJetStreamSupport.DEFAULT_JETSTREAM_POLL_TIMEOUT.toMillis())
+                .build());
+        this.fetchConsumer.set(consumer);
+        try {
+            if (this.consumerContext.get() != context) {
+                return null;
+            }
+            return consumer.nextMessage();
+        } finally {
+            this.fetchConsumer.compareAndSet(consumer, null);
+            closeFetchConsumer(consumer);
+        }
+    }
+
+    private static void closeFetchConsumer(FetchConsumer consumer) {
+        if (consumer == null) {
+            return;
+        }
+        try {
+            consumer.close();
+        } catch (Exception exp) {
+            logger.debug("exception closing JetStream fetch consumer", exp);
+        }
     }
 
     private static class JetStreamAcknowledgmentCallback implements AcknowledgmentCallback {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsConsumerProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsConsumerProperties.java
@@ -16,32 +16,10 @@
 
 package io.nats.cloud.stream.binder.properties;
 
-import io.nats.client.api.DeliverPolicy;
-import io.nats.client.api.ReplayPolicy;
-import io.nats.client.api.StorageType;
-
-import java.time.Duration;
-
 public class NatsConsumerProperties {
     private boolean jetStream;
     private String streamName;
-    private String durableName;
-    private boolean provisionStream;
-    private StorageType streamStorageType;
-    private Integer streamReplicas;
-    private Duration ackWait;
-    private Long maxDeliver;
-    private Long maxAckPending;
-    private DeliverPolicy deliverPolicy;
-    private ReplayPolicy replayPolicy;
-    private Duration idleHeartbeat;
-    private Boolean flowControl;
-    private Duration inactiveThreshold;
-    private Long maxPullWaiting;
-    private Long maxBatch;
-    private Long maxBytes;
-    private Boolean ordered;
-    private Duration pollTimeout;
+    private String consumerName;
 
     /**
      * @return whether this consumer subscribes through JetStream instead of core NATS
@@ -72,240 +50,17 @@ public class NatsConsumerProperties {
     }
 
     /**
-     * @return optional JetStream durable consumer name used for subscriptions
+     * @return optional JetStream consumer name used for subscriptions
      */
-    public String getDurableName() {
-        return this.durableName;
+    public String getConsumerName() {
+        return this.consumerName;
     }
 
     /**
-     * @param durableName optional JetStream durable consumer name used for subscriptions
+     * @param consumerName optional JetStream consumer name used for subscriptions
      */
-    public void setDurableName(String durableName) {
-        this.durableName = durableName;
+    public void setConsumerName(String consumerName) {
+        this.consumerName = consumerName;
     }
 
-    /**
-     * @return whether the binder should create the configured JetStream stream when missing and validate subject coverage when it already exists
-     */
-    public boolean isProvisionStream() {
-        return this.provisionStream;
-    }
-
-    /**
-     * @param provisionStream whether the binder should create the configured JetStream stream when missing and validate subject coverage when it already exists
-     */
-    public void setProvisionStream(boolean provisionStream) {
-        this.provisionStream = provisionStream;
-    }
-
-    /**
-     * @return optional storage type used when a missing JetStream stream is provisioned
-     */
-    public StorageType getStreamStorageType() {
-        return this.streamStorageType;
-    }
-
-    /**
-     * @param streamStorageType optional storage type used when a missing JetStream stream is provisioned
-     */
-    public void setStreamStorageType(StorageType streamStorageType) {
-        this.streamStorageType = streamStorageType;
-    }
-
-    /**
-     * @return optional replica count used when a missing JetStream stream is provisioned
-     */
-    public Integer getStreamReplicas() {
-        return this.streamReplicas;
-    }
-
-    /**
-     * @param streamReplicas optional replica count used when a missing JetStream stream is provisioned
-     */
-    public void setStreamReplicas(Integer streamReplicas) {
-        this.streamReplicas = streamReplicas;
-    }
-
-    /**
-     * @return optional JetStream consumer acknowledgement wait
-     */
-    public Duration getAckWait() {
-        return this.ackWait;
-    }
-
-    /**
-     * @param ackWait optional JetStream consumer acknowledgement wait
-     */
-    public void setAckWait(Duration ackWait) {
-        this.ackWait = ackWait;
-    }
-
-    /**
-     * @return optional maximum delivery attempts for a JetStream consumer
-     */
-    public Long getMaxDeliver() {
-        return this.maxDeliver;
-    }
-
-    /**
-     * @param maxDeliver optional maximum delivery attempts for a JetStream consumer
-     */
-    public void setMaxDeliver(Long maxDeliver) {
-        this.maxDeliver = maxDeliver;
-    }
-
-    /**
-     * @return optional maximum unacknowledged messages for a JetStream consumer
-     */
-    public Long getMaxAckPending() {
-        return this.maxAckPending;
-    }
-
-    /**
-     * @param maxAckPending optional maximum unacknowledged messages for a JetStream consumer
-     */
-    public void setMaxAckPending(Long maxAckPending) {
-        this.maxAckPending = maxAckPending;
-    }
-
-    /**
-     * @return optional JetStream consumer delivery policy
-     */
-    public DeliverPolicy getDeliverPolicy() {
-        return this.deliverPolicy;
-    }
-
-    /**
-     * @param deliverPolicy optional JetStream consumer delivery policy
-     */
-    public void setDeliverPolicy(DeliverPolicy deliverPolicy) {
-        this.deliverPolicy = deliverPolicy;
-    }
-
-    /**
-     * @return optional JetStream consumer replay policy
-     */
-    public ReplayPolicy getReplayPolicy() {
-        return this.replayPolicy;
-    }
-
-    /**
-     * @param replayPolicy optional JetStream consumer replay policy
-     */
-    public void setReplayPolicy(ReplayPolicy replayPolicy) {
-        this.replayPolicy = replayPolicy;
-    }
-
-    /**
-     * @return optional JetStream consumer idle heartbeat
-     */
-    public Duration getIdleHeartbeat() {
-        return this.idleHeartbeat;
-    }
-
-    /**
-     * @param idleHeartbeat optional JetStream consumer idle heartbeat
-     */
-    public void setIdleHeartbeat(Duration idleHeartbeat) {
-        this.idleHeartbeat = idleHeartbeat;
-    }
-
-    /**
-     * @return optional JetStream push consumer flow-control flag
-     */
-    public Boolean getFlowControl() {
-        return this.flowControl;
-    }
-
-    /**
-     * @param flowControl optional JetStream push consumer flow-control flag
-     */
-    public void setFlowControl(Boolean flowControl) {
-        this.flowControl = flowControl;
-    }
-
-    /**
-     * @return optional inactive threshold for an ephemeral JetStream consumer
-     */
-    public Duration getInactiveThreshold() {
-        return this.inactiveThreshold;
-    }
-
-    /**
-     * @param inactiveThreshold optional inactive threshold for an ephemeral JetStream consumer
-     */
-    public void setInactiveThreshold(Duration inactiveThreshold) {
-        this.inactiveThreshold = inactiveThreshold;
-    }
-
-    /**
-     * @return optional maximum outstanding pull requests for a JetStream pull consumer
-     */
-    public Long getMaxPullWaiting() {
-        return this.maxPullWaiting;
-    }
-
-    /**
-     * @param maxPullWaiting optional maximum outstanding pull requests for a JetStream pull consumer
-     */
-    public void setMaxPullWaiting(Long maxPullWaiting) {
-        this.maxPullWaiting = maxPullWaiting;
-    }
-
-    /**
-     * @return optional maximum pull batch size for a JetStream pull consumer
-     */
-    public Long getMaxBatch() {
-        return this.maxBatch;
-    }
-
-    /**
-     * @param maxBatch optional maximum pull batch size for a JetStream pull consumer
-     */
-    public void setMaxBatch(Long maxBatch) {
-        this.maxBatch = maxBatch;
-    }
-
-    /**
-     * @return optional maximum pull byte size for a JetStream pull consumer
-     */
-    public Long getMaxBytes() {
-        return this.maxBytes;
-    }
-
-    /**
-     * @param maxBytes optional maximum pull byte size for a JetStream pull consumer
-     */
-    public void setMaxBytes(Long maxBytes) {
-        this.maxBytes = maxBytes;
-    }
-
-    /**
-     * @return optional ordered-consumer flag for JetStream push consumers
-     */
-    public Boolean getOrdered() {
-        return this.ordered;
-    }
-
-    /**
-     * @param ordered optional ordered-consumer flag for JetStream push consumers
-     */
-    public void setOrdered(Boolean ordered) {
-        this.ordered = ordered;
-    }
-
-    /**
-     * @return optional timeout used by JetStream polled consumers when fetching one message
-     */
-    public Duration getPollTimeout() {
-        return this.pollTimeout;
-    }
-
-    /**
-     * @param pollTimeout optional timeout used by JetStream polled consumers when fetching one message
-     */
-    public void setPollTimeout(Duration pollTimeout) {
-        this.pollTimeout = pollTimeout;
-    }
 }

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
@@ -31,8 +31,6 @@ import io.nats.client.PullSubscribeOptions;
 import io.nats.client.Subscription;
 import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.ConsumerInfo;
-import io.nats.client.api.DeliverPolicy;
-import io.nats.client.api.ReplayPolicy;
 import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.impl.Headers;
@@ -66,6 +64,8 @@ import org.springframework.cloud.stream.binder.RequeueCurrentMessageException;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -221,24 +221,7 @@ class BinderTests {
                 .withPropertyValues(
                         "nats.spring.cloud.stream.bindings.input.consumer.jet-stream=true",
                         "nats.spring.cloud.stream.bindings.input.consumer.stream-name=ORDERS",
-                        "nats.spring.cloud.stream.bindings.input.consumer.durable-name=orders-worker",
-                        "nats.spring.cloud.stream.bindings.input.consumer.provision-stream=true",
-                        "nats.spring.cloud.stream.bindings.input.consumer.stream-storage-type=memory",
-                        "nats.spring.cloud.stream.bindings.input.consumer.stream-replicas=1",
-                        "nats.spring.cloud.stream.bindings.input.consumer.ack-wait=500ms",
-                        "nats.spring.cloud.stream.bindings.input.consumer.max-deliver=3",
-                        "nats.spring.cloud.stream.bindings.input.consumer.max-ack-pending=4",
-                        "nats.spring.cloud.stream.bindings.input.consumer.deliver-policy=new",
-                        "nats.spring.cloud.stream.bindings.input.consumer.replay-policy=instant",
-                        "nats.spring.cloud.stream.bindings.input.consumer.idle-heartbeat=5s",
-                        "nats.spring.cloud.stream.bindings.input.consumer.flow-control=true",
-                        "nats.spring.cloud.stream.bindings.input.consumer.inactive-threshold=30s",
-                        "nats.spring.cloud.stream.bindings.input.consumer.max-pull-waiting=2",
-                        "nats.spring.cloud.stream.bindings.input.consumer.max-batch=1",
-                        "nats.spring.cloud.stream.bindings.input.consumer.max-bytes=1024",
-                        "nats.spring.cloud.stream.bindings.input.consumer.poll-timeout=75ms",
-                        "nats.spring.cloud.stream.bindings.orderedInput.consumer.jet-stream=true",
-                        "nats.spring.cloud.stream.bindings.orderedInput.consumer.ordered=true",
+                        "nats.spring.cloud.stream.bindings.input.consumer.consumer-name=orders-worker",
                         "nats.spring.cloud.stream.bindings.output.producer.jet-stream=true",
                         "nats.spring.cloud.stream.bindings.output.producer.stream-name=ORDERS",
                         "nats.spring.cloud.stream.bindings.output.producer.provision-stream=true",
@@ -250,26 +233,7 @@ class BinderTests {
                     NatsConsumerProperties consumer = properties.getExtendedConsumerProperties("input");
                     assertThat(consumer.isJetStream()).isTrue();
                     assertThat(consumer.getStreamName()).isEqualTo("ORDERS");
-                    assertThat(consumer.getDurableName()).isEqualTo("orders-worker");
-                    assertThat(consumer.isProvisionStream()).isTrue();
-                    assertThat(consumer.getStreamStorageType()).isEqualTo(StorageType.Memory);
-                    assertThat(consumer.getStreamReplicas()).isEqualTo(1);
-                    assertThat(consumer.getAckWait()).isEqualTo(Duration.ofMillis(500));
-                    assertThat(consumer.getMaxDeliver()).isEqualTo(3L);
-                    assertThat(consumer.getMaxAckPending()).isEqualTo(4L);
-                    assertThat(consumer.getDeliverPolicy()).isEqualTo(DeliverPolicy.New);
-                    assertThat(consumer.getReplayPolicy()).isEqualTo(ReplayPolicy.Instant);
-                    assertThat(consumer.getIdleHeartbeat()).isEqualTo(Duration.ofSeconds(5));
-                    assertThat(consumer.getFlowControl()).isTrue();
-                    assertThat(consumer.getInactiveThreshold()).isEqualTo(Duration.ofSeconds(30));
-                    assertThat(consumer.getMaxPullWaiting()).isEqualTo(2L);
-                    assertThat(consumer.getMaxBatch()).isEqualTo(1L);
-                    assertThat(consumer.getMaxBytes()).isEqualTo(1024L);
-                    assertThat(consumer.getPollTimeout()).isEqualTo(Duration.ofMillis(75));
-
-                    NatsConsumerProperties orderedConsumer = properties.getExtendedConsumerProperties("orderedInput");
-                    assertThat(orderedConsumer.isJetStream()).isTrue();
-                    assertThat(orderedConsumer.getOrdered()).isTrue();
+                    assertThat(consumer.getConsumerName()).isEqualTo("orders-worker");
 
                     NatsProducerProperties producer = properties.getExtendedProducerProperties("output");
                     assertThat(producer.isJetStream()).isTrue();
@@ -500,6 +464,39 @@ class BinderTests {
                     producer.stop();
                     producer.stop();
                     assertThat(producer.isRunning()).isFalse();
+                }
+            });
+        }
+    }
+
+    @Test
+    void messageProducerSimpleConstructorReceivesMessage() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer()) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    String subject = "producer.simple.constructor";
+                    NatsConsumerDestination from =
+                            (NatsConsumerDestination) fixture.provisioner().provisionConsumerDestination(subject, "", null);
+                    NatsMessageProducer producer = new NatsMessageProducer(from, fixture.connection());
+                    CompletableFuture<String> received = new CompletableFuture<>();
+                    DirectChannel output = new DirectChannel();
+                    output.subscribe(msg -> received.complete(payloadText(msg.getPayload())));
+                    producer.setOutputChannel(output);
+
+                    try {
+                        producer.start();
+                        fixture.connection().flush(FLUSH_TIMEOUT);
+
+                        conn.publish(subject, "simple".getBytes(UTF_8));
+                        conn.flush(FLUSH_TIMEOUT);
+
+                        assertThat(received.get(5, TimeUnit.SECONDS)).isEqualTo("simple");
+                    } finally {
+                        producer.stop();
+                    }
                 }
             });
         }
@@ -807,7 +804,6 @@ class BinderTests {
         assertThatCode(() -> handler.handleMessage(new GenericMessage<>("ignored"))).doesNotThrowAnyException();
     }
 
-    @Test
     void testMessageHandler() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer()) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
@@ -1315,6 +1311,36 @@ class BinderTests {
     }
 
     @Test
+    void jetStreamProducerProvisioningAppliesStreamOptionsForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
+                    String stream = uniqueNatsName("JS_PROVISION_OPTIONS");
+                    String subject = uniqueSubject("jetstream.provision.options.issue52");
+                    Binding<MessageChannel> producerBinding = null;
+
+                    try {
+                        producerBinding = bindProvisionedJetStreamProducer(fixture, subject, stream, StorageType.Memory, 1);
+
+                        StreamConfiguration configuration = streamInfo(conn, stream).getConfiguration();
+                        assertThat(configuration.getSubjects()).containsExactly(subject);
+                        assertThat(configuration.getStorageType()).isEqualTo(StorageType.Memory);
+                        assertThat(configuration.getReplicas()).isEqualTo(1);
+                    } finally {
+                        if (producerBinding != null) {
+                            producerBinding.unbind();
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    @Test
     void jetStreamProducerProvisioningReportsInvalidStreamConfigurationForIssue52() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
@@ -1528,6 +1554,7 @@ class BinderTests {
                     String subject = uniqueSubject("jetstream.consumer.issue52");
                     String payload = "deliver then ack";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     JetStream js = conn.jetStream();
                     js.publish(subject, headersWithTrace("js-consumer"), payload.getBytes(UTF_8));
@@ -1539,7 +1566,7 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<MessageChannel> consumerBinding = null;
 
                     try {
@@ -1573,11 +1600,11 @@ class BinderTests {
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
                     fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
                     String stream = uniqueNatsName("JS_GROUP");
-                    String durable = uniqueNatsName("js_group_consumer");
                     String group = uniqueNatsName("js_group");
                     String subject = uniqueSubject("jetstream.group.issue52");
                     String payload = "deliver to group";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, group, subject);
 
                     DirectChannel input = new DirectChannel();
                     CompletableFuture<org.springframework.messaging.Message<?>> received = new CompletableFuture<>();
@@ -1586,7 +1613,6 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
                     Binding<MessageChannel> consumerBinding = null;
 
                     try {
@@ -1609,7 +1635,7 @@ class BinderTests {
     }
 
     @Test
-    void jetStreamConsumerProvisioningCreatesStreamAndAppliesConsumerConfigurationForIssue52() throws Exception {
+    void jetStreamConsumerRequiresStreamAndConsumerIdentityForIssue52() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
                 Connection conn = context.getBean(Connection.class);
@@ -1617,10 +1643,84 @@ class BinderTests {
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
                     fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String stream = uniqueNatsName("JS_PROVISION_CONSUMER");
-                    String durable = uniqueNatsName("js_provision_consumer");
-                    String subject = uniqueSubject("jetstream.provision.consumer.issue52");
-                    String payload = "configured consumer";
+                    String stream = uniqueNatsName("JS_CONSUMER_IDENTITY");
+                    String consumer = uniqueNatsName("js_consumer_identity");
+                    String subject = uniqueSubject("jetstream.consumer.identity.issue52");
+                    DirectChannel input = new DirectChannel();
+                    ExtendedConsumerProperties<NatsConsumerProperties> missingStreamProperties =
+                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
+                    missingStreamProperties.getExtension().setJetStream(true);
+                    missingStreamProperties.getExtension().setConsumerName(consumer);
+
+                    assertThatThrownBy(() -> fixture.binder().bindConsumer(subject, "", input, missingStreamProperties))
+                            .isInstanceOf(BinderException.class)
+                            .satisfies(exp -> assertThat(exp.getCause())
+                                    .isInstanceOf(IllegalStateException.class)
+                                    .hasMessage("NATS JetStream consumers require stream-name"));
+
+                    addMemoryStream(conn, stream, subject);
+                    ExtendedConsumerProperties<NatsConsumerProperties> missingConsumerProperties =
+                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
+                    missingConsumerProperties.getExtension().setJetStream(true);
+                    missingConsumerProperties.getExtension().setStreamName(stream);
+
+                    assertThatThrownBy(() -> fixture.binder().bindConsumer(subject, "", input, missingConsumerProperties))
+                            .isInstanceOf(BinderException.class)
+                            .satisfies(exp -> assertThat(exp.getCause())
+                                    .isInstanceOf(IllegalStateException.class)
+                                    .hasMessage("NATS JetStream consumers require consumer-name or a consumer group"));
+                }
+            });
+        }
+    }
+
+    @Test
+    void jetStreamConsumerRequiresExistingNamedConsumerForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
+                    String stream = uniqueNatsName("JS_MISSING_CONSUMER");
+                    String consumer = uniqueNatsName("js_missing_consumer");
+                    String subject = uniqueSubject("jetstream.missing.consumer.issue52");
+                    addMemoryStream(conn, stream, subject);
+                    DirectChannel input = new DirectChannel();
+                    ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
+                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
+                    consumerProperties.getExtension().setJetStream(true);
+                    consumerProperties.getExtension().setStreamName(stream);
+                    consumerProperties.getExtension().setConsumerName(consumer);
+
+                    assertThatThrownBy(() -> fixture.binder().bindConsumer(subject, "", input, consumerProperties))
+                            .isInstanceOf(BinderException.class)
+                            .satisfies(exp -> assertThat(exp.getCause())
+                                    .isInstanceOf(IllegalStateException.class)
+                                    .hasMessageContaining("Failed to subscribe to NATS JetStream subject " + subject));
+                }
+            });
+        }
+    }
+
+    @Test
+    void jetStreamConsumerBindsExistingConsumerConfigurationForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
+                    String stream = uniqueNatsName("JS_EXISTING_CONSUMER");
+                    String consumer = uniqueNatsName("js_existing_consumer");
+                    String subject = uniqueSubject("jetstream.existing.consumer.issue52");
+                    String payload = "configured externally";
+                    addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, consumer, subject, ConsumerConfiguration.builder()
+                            .ackWait(Duration.ofMillis(500))
+                            .maxDeliver(3));
 
                     DirectChannel input = new DirectChannel();
                     CompletableFuture<org.springframework.messaging.Message<?>> received = new CompletableFuture<>();
@@ -1629,269 +1729,23 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
-                    consumerProperties.getExtension().setProvisionStream(true);
-                    consumerProperties.getExtension().setStreamStorageType(StorageType.Memory);
-                    consumerProperties.getExtension().setStreamReplicas(1);
-                    consumerProperties.getExtension().setAckWait(Duration.ofMillis(500));
-                    consumerProperties.getExtension().setMaxDeliver(3L);
-                    consumerProperties.getExtension().setMaxAckPending(7L);
-                    consumerProperties.getExtension().setDeliverPolicy(DeliverPolicy.New);
-                    consumerProperties.getExtension().setReplayPolicy(ReplayPolicy.Instant);
+                    consumerProperties.getExtension().setConsumerName(consumer);
                     Binding<MessageChannel> consumerBinding = null;
 
                     try {
                         consumerBinding = fixture.binder().bindConsumer(subject, "", input, consumerProperties);
                         fixture.connection().flush(FLUSH_TIMEOUT);
 
-                        StreamConfiguration streamConfiguration = streamInfo(conn, stream).getConfiguration();
-                        assertThat(streamConfiguration.getSubjects()).containsExactly(subject);
-                        assertThat(streamConfiguration.getStorageType()).isEqualTo(StorageType.Memory);
-                        assertThat(streamConfiguration.getReplicas()).isEqualTo(1);
+                        conn.jetStream().publish(subject, payload.getBytes(UTF_8));
 
-                        ConsumerConfiguration configuration = consumerInfo(conn, stream, durable).getConsumerConfiguration();
+                        org.springframework.messaging.Message<?> message = received.get(5, TimeUnit.SECONDS);
+                        assertThat(payloadText(message.getPayload())).isEqualTo(payload);
+                        ConsumerConfiguration configuration =
+                                consumerInfo(conn, stream, consumer).getConsumerConfiguration();
                         assertThat(configuration.getAckWait()).isEqualTo(Duration.ofMillis(500));
                         assertThat(configuration.getMaxDeliver()).isEqualTo(3);
-                        assertThat(configuration.getMaxAckPending()).isEqualTo(7);
-                        assertThat(configuration.getDeliverPolicy()).isEqualTo(DeliverPolicy.New);
-                        assertThat(configuration.getReplayPolicy()).isEqualTo(ReplayPolicy.Instant);
-
-                        conn.jetStream().publish(subject, payload.getBytes(UTF_8));
-
-                        org.springframework.messaging.Message<?> message = received.get(5, TimeUnit.SECONDS);
-                        assertThat(payloadText(message.getPayload())).isEqualTo(payload);
                         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
-                                assertThat(consumerInfo(conn, stream, durable).getNumAckPending()).isZero());
-                    } finally {
-                        if (consumerBinding != null) {
-                            consumerBinding.unbind();
-                        }
-                    }
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamPushConsumerAppliesHeartbeatAndFlowControlConfigurationForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String heartbeatStream = uniqueNatsName("JS_PUSH_HEARTBEAT");
-                    String heartbeatDurable = uniqueNatsName("js_push_heartbeat");
-                    String heartbeatSubject = uniqueSubject("jetstream.push.heartbeat.issue52");
-                    String flowControlStream = uniqueNatsName("JS_PUSH_FLOW");
-                    String flowControlDurable = uniqueNatsName("js_push_flow");
-                    String flowControlSubject = uniqueSubject("jetstream.push.flow.issue52");
-                    addMemoryStream(conn, heartbeatStream, heartbeatSubject);
-                    addMemoryStream(conn, flowControlStream, flowControlSubject);
-
-                    DirectChannel heartbeatInput = new DirectChannel();
-                    DirectChannel flowControlInput = new DirectChannel();
-                    ExtendedConsumerProperties<NatsConsumerProperties> heartbeatProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    heartbeatProperties.getExtension().setJetStream(true);
-                    heartbeatProperties.getExtension().setStreamName(heartbeatStream);
-                    heartbeatProperties.getExtension().setDurableName(heartbeatDurable);
-                    heartbeatProperties.getExtension().setIdleHeartbeat(Duration.ofMillis(500));
-                    heartbeatProperties.getExtension().setInactiveThreshold(Duration.ofSeconds(30));
-                    ExtendedConsumerProperties<NatsConsumerProperties> flowControlProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    flowControlProperties.getExtension().setJetStream(true);
-                    flowControlProperties.getExtension().setStreamName(flowControlStream);
-                    flowControlProperties.getExtension().setDurableName(flowControlDurable);
-                    flowControlProperties.getExtension().setIdleHeartbeat(Duration.ofMillis(500));
-                    flowControlProperties.getExtension().setFlowControl(true);
-                    Binding<MessageChannel> heartbeatBinding = null;
-                    Binding<MessageChannel> flowControlBinding = null;
-
-                    try {
-                        heartbeatBinding = fixture.binder().bindConsumer(heartbeatSubject, "", heartbeatInput, heartbeatProperties);
-                        flowControlBinding = fixture.binder().bindConsumer(flowControlSubject, "", flowControlInput, flowControlProperties);
-                        fixture.connection().flush(FLUSH_TIMEOUT);
-
-                        ConsumerConfiguration heartbeatConfiguration =
-                                consumerInfo(conn, heartbeatStream, heartbeatDurable).getConsumerConfiguration();
-                        assertThat(heartbeatConfiguration.getIdleHeartbeat()).isEqualTo(Duration.ofMillis(500));
-                        assertThat(heartbeatConfiguration.isFlowControl()).isFalse();
-                        assertThat(heartbeatConfiguration.getInactiveThreshold()).isEqualTo(Duration.ofSeconds(30));
-
-                        ConsumerConfiguration flowControlConfiguration =
-                                consumerInfo(conn, flowControlStream, flowControlDurable).getConsumerConfiguration();
-                        assertThat(flowControlConfiguration.getIdleHeartbeat()).isEqualTo(Duration.ofMillis(500));
-                        assertThat(flowControlConfiguration.isFlowControl()).isTrue();
-                    } finally {
-                        if (flowControlBinding != null) {
-                            flowControlBinding.unbind();
-                        }
-                        if (heartbeatBinding != null) {
-                            heartbeatBinding.unbind();
-                        }
-                    }
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamGroupedPushConsumerRejectsHeartbeatAndFlowControlForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String heartbeatStream = uniqueNatsName("JS_GROUP_HEARTBEAT");
-                    String heartbeatSubject = uniqueSubject("jetstream.group.heartbeat.issue52");
-                    String flowControlStream = uniqueNatsName("JS_GROUP_FLOW");
-                    String flowControlSubject = uniqueSubject("jetstream.group.flow.issue52");
-                    String group = uniqueNatsName("js_group_validation");
-                    addMemoryStream(conn, heartbeatStream, heartbeatSubject);
-                    addMemoryStream(conn, flowControlStream, flowControlSubject);
-
-                    ExtendedConsumerProperties<NatsConsumerProperties> heartbeatProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    heartbeatProperties.getExtension().setJetStream(true);
-                    heartbeatProperties.getExtension().setStreamName(heartbeatStream);
-                    heartbeatProperties.getExtension().setIdleHeartbeat(Duration.ofMillis(500));
-                    ExtendedConsumerProperties<NatsConsumerProperties> flowControlProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    flowControlProperties.getExtension().setJetStream(true);
-                    flowControlProperties.getExtension().setStreamName(flowControlStream);
-                    flowControlProperties.getExtension().setFlowControl(true);
-
-                    assertThatThrownBy(() -> fixture.binder().bindConsumer(heartbeatSubject, group,
-                            new DirectChannel(), heartbeatProperties))
-                            .isInstanceOfAny(BinderException.class, IllegalArgumentException.class)
-                            .hasStackTraceContaining("flow-control and idle-heartbeat are not supported with consumer groups");
-                    assertThatThrownBy(() -> fixture.binder().bindConsumer(flowControlSubject, group,
-                            new DirectChannel(), flowControlProperties))
-                            .isInstanceOfAny(BinderException.class, IllegalArgumentException.class)
-                            .hasStackTraceContaining("flow-control and idle-heartbeat are not supported with consumer groups");
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamPushConsumerRejectsFlowControlWithoutHeartbeatForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String stream = uniqueNatsName("JS_FLOW_WITHOUT_HEARTBEAT");
-                    String subject = uniqueSubject("jetstream.flow.without.heartbeat.issue52");
-                    addMemoryStream(conn, stream, subject);
-
-                    ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    consumerProperties.getExtension().setJetStream(true);
-                    consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setFlowControl(true);
-
-                    assertThatThrownBy(() -> fixture.binder().bindConsumer(subject, "",
-                            new DirectChannel(), consumerProperties))
-                            .isInstanceOfAny(BinderException.class, IllegalArgumentException.class)
-                            .hasStackTraceContaining("flow-control requires idle-heartbeat");
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamOrderedPushConsumerRejectsIncompatibleOptionsForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String durableStream = uniqueNatsName("JS_ORDERED_DURABLE");
-                    String durableSubject = uniqueSubject("jetstream.ordered.durable.issue52");
-                    String groupStream = uniqueNatsName("JS_ORDERED_GROUP");
-                    String groupSubject = uniqueSubject("jetstream.ordered.group.issue52");
-                    String maxDeliverStream = uniqueNatsName("JS_ORDERED_MAX_DELIVER");
-                    String maxDeliverSubject = uniqueSubject("jetstream.ordered.max.deliver.issue52");
-                    addMemoryStream(conn, durableStream, durableSubject);
-                    addMemoryStream(conn, groupStream, groupSubject);
-                    addMemoryStream(conn, maxDeliverStream, maxDeliverSubject);
-
-                    ExtendedConsumerProperties<NatsConsumerProperties> durableProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    durableProperties.getExtension().setJetStream(true);
-                    durableProperties.getExtension().setStreamName(durableStream);
-                    durableProperties.getExtension().setDurableName(uniqueNatsName("js_ordered_durable"));
-                    durableProperties.getExtension().setOrdered(true);
-                    ExtendedConsumerProperties<NatsConsumerProperties> groupProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    groupProperties.getExtension().setJetStream(true);
-                    groupProperties.getExtension().setStreamName(groupStream);
-                    groupProperties.getExtension().setOrdered(true);
-                    ExtendedConsumerProperties<NatsConsumerProperties> maxDeliverProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    maxDeliverProperties.getExtension().setJetStream(true);
-                    maxDeliverProperties.getExtension().setStreamName(maxDeliverStream);
-                    maxDeliverProperties.getExtension().setOrdered(true);
-                    maxDeliverProperties.getExtension().setMaxDeliver(2L);
-
-                    assertThatThrownBy(() -> fixture.binder().bindConsumer(durableSubject, "",
-                            new DirectChannel(), durableProperties))
-                            .isInstanceOfAny(BinderException.class, IllegalArgumentException.class)
-                            .hasStackTraceContaining("ordered consumers cannot use durable-name");
-                    assertThatThrownBy(() -> fixture.binder().bindConsumer(groupSubject, uniqueNatsName("js_ordered_group"),
-                            new DirectChannel(), groupProperties))
-                            .isInstanceOfAny(BinderException.class, IllegalArgumentException.class)
-                            .hasStackTraceContaining("ordered consumers cannot use consumer groups");
-                    assertThatThrownBy(() -> fixture.binder().bindConsumer(maxDeliverSubject, "",
-                            new DirectChannel(), maxDeliverProperties))
-                            .isInstanceOfAny(BinderException.class, IllegalArgumentException.class)
-                            .hasStackTraceContaining("ordered consumers require max-deliver to be unset or 1");
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamOrderedPushConsumerReceivesMessageForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String stream = uniqueNatsName("JS_ORDERED");
-                    String subject = uniqueSubject("jetstream.ordered.issue52");
-                    String payload = "ordered delivery";
-                    addMemoryStream(conn, stream, subject);
-
-                    DirectChannel input = new DirectChannel();
-                    CompletableFuture<org.springframework.messaging.Message<?>> received = new CompletableFuture<>();
-                    input.subscribe(received::complete);
-                    ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    consumerProperties.getExtension().setJetStream(true);
-                    consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setOrdered(true);
-                    Binding<MessageChannel> consumerBinding = null;
-
-                    try {
-                        consumerBinding = fixture.binder().bindConsumer(subject, "", input, consumerProperties);
-                        fixture.connection().flush(FLUSH_TIMEOUT);
-
-                        conn.jetStream().publish(subject, payload.getBytes(UTF_8));
-
-                        org.springframework.messaging.Message<?> message = received.get(5, TimeUnit.SECONDS);
-                        assertThat(payloadText(message.getPayload())).isEqualTo(payload);
+                                assertThat(consumerInfo(conn, stream, consumer).getNumAckPending()).isZero());
                     } finally {
                         if (consumerBinding != null) {
                             consumerBinding.unbind();
@@ -1916,6 +1770,7 @@ class BinderTests {
                     String subject = uniqueSubject("jetstream.rejected.send.issue52");
                     String payload = "redeliver rejected send";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     AtomicInteger attempts = new AtomicInteger();
                     CompletableFuture<org.springframework.messaging.Message<?>> redelivered = new CompletableFuture<>();
@@ -1938,7 +1793,7 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<MessageChannel> consumerBinding = null;
 
                     try {
@@ -1976,6 +1831,7 @@ class BinderTests {
                     String subject = uniqueSubject("jetstream.throwing.send.issue52");
                     String payload = "redeliver thrown send";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     AtomicInteger attempts = new AtomicInteger();
                     CompletableFuture<org.springframework.messaging.Message<?>> redelivered = new CompletableFuture<>();
@@ -1998,7 +1854,7 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<MessageChannel> consumerBinding = null;
 
                     try {
@@ -2036,6 +1892,7 @@ class BinderTests {
                     String subject = uniqueSubject("jetstream.polled.issue52");
                     String payload = "poll then ack";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     JetStream js = conn.jetStream();
                     js.publish(subject, headersWithTrace("js-polled"), payload.getBytes(UTF_8));
@@ -2046,7 +1903,7 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<?> consumerBinding = null;
 
                     try {
@@ -2073,6 +1930,88 @@ class BinderTests {
     }
 
     @Test
+    void jetStreamPolledConsumerReceiveReturnsNullWhenStoppedForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    String stream = uniqueNatsName("JS_POLLED_STOPPED");
+                    String consumer = uniqueNatsName("js_polled_stopped");
+                    String subject = uniqueSubject("jetstream.polled.stopped.issue52");
+                    addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, consumer, subject);
+                    NatsConsumerDestination from = (NatsConsumerDestination) fixture.provisioner()
+                            .provisionConsumerDestination(subject, "", null);
+                    NatsMessageSource source = new NatsMessageSource(
+                            from,
+                            fixture.connection(),
+                            true,
+                            true,
+                            true,
+                            stream,
+                            consumer);
+
+                    assertThat(source.receive()).isNull();
+                }
+            });
+        }
+    }
+
+    @Test
+    void jetStreamPolledConsumerAcknowledgmentCallbackIgnoresRepeatForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    String stream = uniqueNatsName("JS_POLLED_REPEAT_ACK");
+                    String consumer = uniqueNatsName("js_polled_repeat_ack");
+                    String subject = uniqueSubject("jetstream.polled.repeat.ack.issue52");
+                    String payload = "ack once";
+                    addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, consumer, subject);
+                    NatsConsumerDestination from = (NatsConsumerDestination) fixture.provisioner()
+                            .provisionConsumerDestination(subject, "", null);
+                    NatsMessageSource source = new NatsMessageSource(
+                            from,
+                            fixture.connection(),
+                            true,
+                            true,
+                            true,
+                            stream,
+                            consumer);
+
+                    try {
+                        source.start();
+                        conn.jetStream().publish(subject, payload.getBytes(UTF_8));
+
+                        org.springframework.messaging.Message<Object> message = source.receive();
+                        assertThat(message).isNotNull();
+                        assertThat(payloadText(message.getPayload())).isEqualTo(payload);
+                        AcknowledgmentCallback callback = message.getHeaders().get(
+                                IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK,
+                                AcknowledgmentCallback.class);
+                        assertThat(callback).isNotNull();
+                        assertThat(callback.isAcknowledged()).isFalse();
+
+                        callback.acknowledge(AcknowledgmentCallback.Status.ACCEPT);
+                        callback.acknowledge(AcknowledgmentCallback.Status.ACCEPT);
+
+                        assertThat(callback.isAcknowledged()).isTrue();
+                        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                                assertThat(consumerInfo(conn, stream, consumer).getNumAckPending()).isZero());
+                    } finally {
+                        source.stop();
+                    }
+                }
+            });
+        }
+    }
+
+    @Test
     void jetStreamPolledConsumerReturnsFalseWhenNoMessageIsAvailableForIssue52() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
@@ -2085,13 +2024,14 @@ class BinderTests {
                     String durable = uniqueNatsName("js_polled_empty");
                     String subject = uniqueSubject("jetstream.polled.empty.issue52");
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
                     ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<?> consumerBinding = null;
 
                     try {
@@ -2115,7 +2055,7 @@ class BinderTests {
     }
 
     @Test
-    void jetStreamPolledConsumerUsesConfiguredPollTimeoutForIssue52() throws Exception {
+    void jetStreamPolledConsumerRequiresStreamAndConsumerIdentityForIssue52() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
                 Connection conn = context.getBean(Connection.class);
@@ -2123,113 +2063,32 @@ class BinderTests {
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
                     fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String stream = uniqueNatsName("JS_POLLED_TIMEOUT");
-                    String durable = uniqueNatsName("js_polled_timeout");
-                    String subject = uniqueSubject("jetstream.polled.timeout.issue52");
-                    addMemoryStream(conn, stream, subject);
+                    String stream = uniqueNatsName("JS_POLLED_IDENTITY");
+                    String consumer = uniqueNatsName("js_polled_identity");
+                    String subject = uniqueSubject("jetstream.polled.identity.issue52");
 
-                    DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
-                    ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
+                    DefaultPollableMessageSource missingStreamSource = new DefaultPollableMessageSource(null);
+                    ExtendedConsumerProperties<NatsConsumerProperties> missingStreamProperties =
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    consumerProperties.getExtension().setJetStream(true);
-                    consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
-                    consumerProperties.getExtension().setPollTimeout(Duration.ofMillis(800));
-                    Binding<?> consumerBinding = null;
+                    missingStreamProperties.getExtension().setJetStream(true);
+                    missingStreamProperties.getExtension().setConsumerName(consumer);
 
-                    try {
-                        consumerBinding = fixture.binder().bindPollableConsumer(subject, "", source, consumerProperties);
-                        source.start();
+                    assertThatThrownBy(() -> fixture.binder().bindPollableConsumer(subject, "",
+                            missingStreamSource, missingStreamProperties))
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessage("NATS JetStream polled consumers require stream-name");
 
-                        long started = System.nanoTime();
-                        assertThat(source.poll(message -> {
-                            throw new AssertionError("unexpected message");
-                        })).isFalse();
-                        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started);
-                        assertThat(elapsedMillis).isGreaterThanOrEqualTo(650);
-                    } finally {
-                        source.stop();
-                        if (consumerBinding != null) {
-                            consumerBinding.unbind();
-                        }
-                    }
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamPolledConsumerRejectsNonPositivePollTimeoutForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String stream = uniqueNatsName("JS_POLLED_BAD_TIMEOUT");
-                    String durable = uniqueNatsName("js_polled_bad_timeout");
-                    String subject = uniqueSubject("jetstream.polled.bad.timeout.issue52");
                     addMemoryStream(conn, stream, subject);
-
-                    DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
-                    ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
+                    DefaultPollableMessageSource missingConsumerSource = new DefaultPollableMessageSource(null);
+                    ExtendedConsumerProperties<NatsConsumerProperties> missingConsumerProperties =
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    consumerProperties.getExtension().setJetStream(true);
-                    consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
-                    consumerProperties.getExtension().setPollTimeout(Duration.ZERO);
+                    missingConsumerProperties.getExtension().setJetStream(true);
+                    missingConsumerProperties.getExtension().setStreamName(stream);
 
-                    assertThatThrownBy(() -> fixture.binder().bindPollableConsumer(subject, "", source, consumerProperties))
-                            .isInstanceOf(IllegalArgumentException.class)
-                            .hasMessage("NATS JetStream poll-timeout must be greater than zero");
-                }
-            });
-        }
-    }
-
-    @Test
-    void jetStreamPolledConsumerAppliesPullConsumerConfigurationForIssue52() throws Exception {
-        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
-            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
-                Connection conn = context.getBean(Connection.class);
-                assertConnected(conn, ts.getURI());
-
-                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    fixture.binder().setApplicationContext(context.getSourceApplicationContext(GenericApplicationContext.class));
-                    String stream = uniqueNatsName("JS_POLLED_CONFIG");
-                    String durable = uniqueNatsName("js_polled_config");
-                    String subject = uniqueSubject("jetstream.polled.config.issue52");
-                    addMemoryStream(conn, stream, subject);
-
-                    DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
-                    ExtendedConsumerProperties<NatsConsumerProperties> consumerProperties =
-                            new ExtendedConsumerProperties<>(new NatsConsumerProperties());
-                    consumerProperties.getExtension().setJetStream(true);
-                    consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
-                    consumerProperties.getExtension().setInactiveThreshold(Duration.ofSeconds(30));
-                    consumerProperties.getExtension().setMaxPullWaiting(2L);
-                    consumerProperties.getExtension().setMaxBatch(1L);
-                    consumerProperties.getExtension().setMaxBytes(1024L);
-                    Binding<?> consumerBinding = null;
-
-                    try {
-                        consumerBinding = fixture.binder().bindPollableConsumer(subject, "", source, consumerProperties);
-                        source.start();
-
-                        ConsumerConfiguration configuration =
-                                consumerInfo(conn, stream, durable).getConsumerConfiguration();
-                        assertThat(configuration.getInactiveThreshold()).isEqualTo(Duration.ofSeconds(30));
-                        assertThat(configuration.getMaxPullWaiting()).isEqualTo(2);
-                        assertThat(configuration.getMaxBatch()).isEqualTo(1);
-                        assertThat(configuration.getMaxBytes()).isEqualTo(1024);
-                    } finally {
-                        source.stop();
-                        if (consumerBinding != null) {
-                            consumerBinding.unbind();
-                        }
-                    }
+                    assertThatThrownBy(() -> fixture.binder().bindPollableConsumer(subject, "",
+                            missingConsumerSource, missingConsumerProperties))
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessage("NATS JetStream polled consumers require consumer-name or a consumer group");
                 }
             });
         }
@@ -2249,6 +2108,7 @@ class BinderTests {
                     String subject = uniqueSubject("jetstream.polled.requeue.issue52");
                     String payload = "requeue me";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
                     AtomicReference<org.springframework.messaging.Message<?>> redelivered = new AtomicReference<>();
@@ -2256,7 +2116,7 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<?> consumerBinding = null;
 
                     try {
@@ -2302,6 +2162,7 @@ class BinderTests {
                     String subject = uniqueSubject("jetstream.polled.exception.issue52");
                     String payload = "retry after exception";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, durable, subject);
 
                     DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
                     AtomicReference<org.springframework.messaging.Message<?>> redelivered = new AtomicReference<>();
@@ -2309,7 +2170,7 @@ class BinderTests {
                             new ExtendedConsumerProperties<>(new NatsConsumerProperties());
                     consumerProperties.getExtension().setJetStream(true);
                     consumerProperties.getExtension().setStreamName(stream);
-                    consumerProperties.getExtension().setDurableName(durable);
+                    consumerProperties.getExtension().setConsumerName(durable);
                     Binding<?> consumerBinding = null;
 
                     try {
@@ -2342,7 +2203,7 @@ class BinderTests {
     }
 
     @Test
-    void jetStreamPolledConsumerUsesGroupAsDurableWhenDurableNameIsUnsetForIssue52() throws Exception {
+    void jetStreamPolledConsumerUsesGroupAsConsumerNameWhenConsumerNameIsUnsetForIssue52() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
                 Connection conn = context.getBean(Connection.class);
@@ -2353,8 +2214,9 @@ class BinderTests {
                     String stream = uniqueNatsName("JS_POLLED_GROUP");
                     String group = uniqueNatsName("js_polled_group");
                     String subject = uniqueSubject("jetstream.polled.group.issue52");
-                    String payload = "group durable";
+                    String payload = "group consumer";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, group, subject);
 
                     DefaultPollableMessageSource source = new DefaultPollableMessageSource(null);
                     AtomicReference<org.springframework.messaging.Message<?>> received = new AtomicReference<>();
@@ -2387,17 +2249,19 @@ class BinderTests {
     }
 
     @Test
-    void jetStreamPolledConsumerCanResolveStreamFromSubjectForIssue52() throws Exception {
+    void jetStreamPolledConsumerUsesNamedConsumerContextForIssue52() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
                 Connection conn = context.getBean(Connection.class);
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
-                    String stream = uniqueNatsName("JS_POLLED_RESOLVE");
-                    String subject = uniqueSubject("jetstream.polled.resolve.issue52");
-                    String payload = "poll resolved stream";
+                    String stream = uniqueNatsName("JS_POLLED_CONTEXT");
+                    String consumer = uniqueNatsName("js_polled_context");
+                    String subject = uniqueSubject("jetstream.polled.context.issue52");
+                    String payload = "poll named consumer";
                     addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, consumer, subject);
 
                     NatsConsumerDestination from = (NatsConsumerDestination) fixture.provisioner()
                             .provisionConsumerDestination(subject, "", null);
@@ -2407,8 +2271,8 @@ class BinderTests {
                             true,
                             true,
                             true,
-                            null,
-                            null);
+                            stream,
+                            consumer);
 
                     try {
                         src.start();
@@ -2451,6 +2315,31 @@ class BinderTests {
                             .build()))
                             .isInstanceOf(MessageHandlingException.class)
                             .hasMessageContaining("JetStream publishing does not support reply channels");
+                }
+            });
+        }
+    }
+
+    @Test
+    void jetStreamProducerReportsServerPublishFailureForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    String stream = uniqueNatsName("JS_MISSING_PUBLISH");
+                    String subject = uniqueSubject("jetstream.missing.publish.issue52");
+                    ExtendedProducerProperties<NatsProducerProperties> producerProperties =
+                            new ExtendedProducerProperties<>(new NatsProducerProperties());
+                    producerProperties.getExtension().setJetStream(true);
+                    producerProperties.getExtension().setStreamName(stream);
+                    ProducerDestination to = fixture.provisioner().provisionProducerDestination(subject, null);
+                    MessageHandler handler = fixture.binder().createProducerMessageHandler(to, producerProperties, null);
+
+                    assertThatThrownBy(() -> handler.handleMessage(MessageBuilder.withPayload("missing stream").build()))
+                            .isInstanceOf(MessageHandlingException.class)
+                            .hasMessageContaining("Failed to publish message to NATS JetStream subject " + subject);
                 }
             });
         }
@@ -2898,9 +2787,23 @@ class BinderTests {
                 .build());
     }
 
-    private static ConsumerInfo consumerInfo(Connection connection, String stream, String durable) {
+    private static ConsumerInfo addConsumer(Connection connection, String stream, String consumer, String subject)
+            throws IOException, JetStreamApiException {
+        return addConsumer(connection, stream, consumer, subject, ConsumerConfiguration.builder());
+    }
+
+    private static ConsumerInfo addConsumer(Connection connection, String stream, String consumer, String subject,
+                                            ConsumerConfiguration.Builder builder)
+            throws IOException, JetStreamApiException {
+        return connection.jetStreamManagement().addOrUpdateConsumer(stream, builder
+                .durable(consumer)
+                .filterSubject(subject)
+                .build());
+    }
+
+    private static ConsumerInfo consumerInfo(Connection connection, String stream, String consumer) {
         try {
-            return connection.jetStreamManagement().getConsumerInfo(stream, durable);
+            return connection.jetStreamManagement().getConsumerInfo(stream, consumer);
         } catch (IOException | JetStreamApiException exp) {
             throw new AssertionError(exp);
         }

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
@@ -804,6 +804,7 @@ class BinderTests {
         assertThatCode(() -> handler.handleMessage(new GenericMessage<>("ignored"))).doesNotThrowAnyException();
     }
 
+    @Test
     void testMessageHandler() throws Exception {
         try (NatsBinderTestServer ts = new NatsBinderTestServer()) {
             this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
@@ -1954,6 +1955,48 @@ class BinderTests {
                             consumer);
 
                     assertThat(source.receive()).isNull();
+                }
+            });
+        }
+    }
+
+    @Test
+    void jetStreamPolledConsumerStopUnblocksIdleReceiveForIssue52() throws Exception {
+        try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"-js"}, false)) {
+            this.contextRunner.withPropertyValues("nats.spring.server=" + ts.getURI()).run(context -> {
+                Connection conn = context.getBean(Connection.class);
+                assertConnected(conn, ts.getURI());
+
+                try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    String stream = uniqueNatsName("JS_POLLED_STOP_IDLE");
+                    String consumer = uniqueNatsName("js_polled_stop_idle");
+                    String subject = uniqueSubject("jetstream.polled.stop.idle.issue52");
+                    addMemoryStream(conn, stream, subject);
+                    addConsumer(conn, stream, consumer, subject);
+                    NatsConsumerDestination from = (NatsConsumerDestination) fixture.provisioner()
+                            .provisionConsumerDestination(subject, "", null);
+                    NatsMessageSource source = new NatsMessageSource(
+                            from,
+                            fixture.connection(),
+                            true,
+                            true,
+                            true,
+                            stream,
+                            consumer);
+
+                    try {
+                        source.start();
+                        CompletableFuture<org.springframework.messaging.Message<Object>> receive =
+                                CompletableFuture.supplyAsync(source::receive);
+                        Thread.sleep(100);
+                        assertThat(receive).isNotDone();
+
+                        source.stop();
+
+                        assertThat(receive.get(500, TimeUnit.MILLISECONDS)).isNull();
+                    } finally {
+                        source.stop();
+                    }
                 }
             });
         }

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/DestinationNameTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/DestinationNameTests.java
@@ -51,6 +51,11 @@ public class DestinationNameTests {
 
         assertEquals(subject, dest.getSubject());
         assertEquals("", dest.getQueueGroup());
+
+        dest = new NatsConsumerDestination(subject);
+
+        assertEquals(subject, dest.getSubject());
+        assertEquals("", dest.getQueueGroup());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Simplify JetStream consumer properties to stream and consumer identity only.
- Bind JetStream event consumers through jnats `ConsumerContext`.
- Bind JetStream polled consumers through jnats `ConsumerContext.fetch(...)` so `stop()` can close an in-flight idle receive.
- Require JetStream consumers to be created externally with NATS or `ConsumerConfiguration` before binding.
- Keep producer-side stream provisioning and update README/tests for the new contract.

## Validation

- `mvn -pl nats-spring-cloud-stream-binder -DskipTests compile test-compile`
- `mvn -pl nats-spring-cloud-stream-binder -Dtest=BinderTests test`
- `mvn -pl nats-spring-cloud-stream-binder test`
- Coverage: line `96.48%`, branch `91.49%`
