### PR TITLE
Support noNoResponders configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ By default, properties are configured using the `nats.spring` prefix:
 * `nats.spring.reconnect-buffer-size` the size in bytes for the reconnect buffer
 * `nats.spring.inbox-prefix` a custom inbox prefix
 * `nats.spring.no-echo` turn off echo from the server
+* `nats.spring.no-no-responders` disable no responders support
 * `nats.spring.utf8-support` enable UTF-8 subject names (warning this is an experimental feature, not all language clients will support it)
 * `nats.spring.username`, `nats.spring.password` the user name and password to authenticate with
 * `nats.spring.token` an authentication token, takes precedence over the username/password

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
@@ -103,6 +103,11 @@ public class NatsConnectionProperties {
     private boolean noEcho;
 
     /**
+     * Whether or not to disable no responders support.
+     */
+    private boolean noNoResponders;
+
+    /**
      * Whether or not to treat subjects as UTF-8, the default is ASCII.
      */
     private boolean utf8Support;
@@ -435,6 +440,27 @@ public class NatsConnectionProperties {
     }
 
     /**
+     * @return whether or not to disable no responders support, see {@link Options.Builder#noNoResponders() noNoResponders()} in the builder doc
+     */
+    public boolean isNoNoResponders() {
+        return this.noNoResponders;
+    }
+
+    /**
+     * @return whether or not to disable no responders support, see {@link Options.Builder#noNoResponders() noNoResponders()} in the builder doc
+     */
+    public boolean getNoNoResponders() {
+        return this.noNoResponders;
+    }
+
+    /**
+     * @param noNoResponders whether or not to disable no responders support, see {@link Options.Builder#noNoResponders() noNoResponders()} in the builder doc
+     */
+    public void setNoNoResponders(boolean noNoResponders) {
+        this.noNoResponders = noNoResponders;
+    }
+
+    /**
      * @return whether or not the client should support for UTF8 subject names
      */
     public boolean isUtf8Support() {
@@ -764,6 +790,15 @@ public class NatsConnectionProperties {
     }
 
     /**
+     * @param noNoResponders whether or not to disable no responders support
+     * @return chainable properties
+     */
+    public NatsConnectionProperties noNoResponders(boolean noNoResponders) {
+        this.noNoResponders = noNoResponders;
+        return this;
+    }
+
+    /**
      * @param utf8Support whether or not to support utf8 subject names
      * @return chainable properties
      */
@@ -1005,6 +1040,10 @@ public class NatsConnectionProperties {
             builder = builder.noEcho();
         }
 
+        if (this.noNoResponders) {
+            builder = builder.noNoResponders();
+        }
+
         if (this.utf8Support) {
             builder = builder.supportUTF8Subjects();
         }
@@ -1047,6 +1086,7 @@ public class NatsConnectionProperties {
                 + " reconnectBufferSize='" + getReconnectBufferSize() + "',"
                 + " noResolveHostnames='" + getNoResolveHostnames() + "',"
                 + " noEcho='" + getNoEcho() + "',"
+                + " noNoResponders='" + getNoNoResponders() + "',"
                 + " tlsFirst='" + getTlsFirst() + "',"
                 + " utf8='" + getUtf8Support() + "',"
                 + " user=" + redact(getUsername()) + ","

--- a/nats-spring/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/nats-spring/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -75,6 +75,13 @@
             "defaultValue": false
         },
         {
+            "name": "nats.spring.no-no-responders",
+            "type": "java.lang.Boolean",
+            "description": "Whether or not to disable no responders support.",
+            "sourceType": "io.nats.spring.boot.autoconfigure.NatsProperties",
+            "defaultValue": false
+        },
+        {
             "name": "nats.spring.password",
             "type": "java.lang.String",
             "description": "Authentication password. Requires the username, but not the token, or credentials, or NKey.",

--- a/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/AutoconfigureTests.java
+++ b/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/AutoconfigureTests.java
@@ -146,6 +146,20 @@ class AutoconfigureTests {
     }
 
     @Test
+    void noNoRespondersBindsToRealConnectionOptions() throws IOException, InterruptedException {
+        try (NatsTestServer ts = new NatsTestServer()) {
+            this.contextRunner.withPropertyValues(
+                    "nats.spring.server=" + ts.getURI(),
+                    "nats.spring.no-no-responders=true").run(context -> {
+                Connection conn = context.getBean(Connection.class);
+
+                assertThat(conn.getStatus()).isSameAs(Connection.Status.CONNECTED);
+                assertThat(conn.getOptions().isNoNoResponders()).isTrue();
+            });
+        }
+    }
+
+    @Test
     void utf8SubjectsCanRoundTripThroughRealServer() throws IOException, InterruptedException {
         try (NatsTestServer ts = new NatsTestServer()) {
             this.contextRunner.withPropertyValues(

--- a/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/PropertiesTests.java
+++ b/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/PropertiesTests.java
@@ -144,6 +144,44 @@ public class PropertiesTests {
     }
 
     @Test
+    public void noNoRespondersDefaultsToFalseInOptions() throws Exception {
+        NatsConnectionProperties props = new NatsConnectionProperties();
+        props.setServer("nats://alphabet:4222");
+
+        Options options = props.toOptions();
+
+        assertFalse(props.getNoNoResponders());
+        assertFalse(props.isNoNoResponders());
+        assertFalse(options.isNoNoResponders());
+    }
+
+    @Test
+    public void noNoRespondersSetterDisablesNoRespondersSupportInOptions() throws Exception {
+        NatsConnectionProperties props = new NatsConnectionProperties();
+        props.setServer("nats://alphabet:4222");
+        props.setNoNoResponders(true);
+
+        Options options = props.toOptions();
+
+        assertTrue(props.getNoNoResponders());
+        assertTrue(props.isNoNoResponders());
+        assertTrue(options.isNoNoResponders());
+    }
+
+    @Test
+    public void noNoRespondersFluentPropertyDisablesNoRespondersSupportInOptions() throws Exception {
+        NatsConnectionProperties props = new NatsConnectionProperties()
+                .server("nats://alphabet:4222")
+                .noNoResponders(true);
+
+        Options options = props.toOptions();
+
+        assertTrue(props.getNoNoResponders());
+        assertTrue(props.isNoNoResponders());
+        assertTrue(options.isNoNoResponders());
+    }
+
+    @Test
     public void testFluentProperties() throws Exception {
         String server = "nats://alphabet:4222";
         String connectionName = "alpha";


### PR DESCRIPTION
## Summary

- Expose `nats.spring.no-no-responders` on `NatsConnectionProperties`.
- Pass the flag through to `Options.Builder.noNoResponders()`.
- Document the property and add Spring configuration metadata.
- Cover direct options mapping and real Spring autoconfiguration binding.

## Issue

Related to #72. This handles the `noNoResponders` configuration support only; prefix renaming is intentionally out of scope so existing `nats.spring` users remain compatible.

## Verification

- `./mvnw -pl nats-spring -Dtest=PropertiesTests,AutoconfigureTests test`
- `./mvnw test`
- `nats-spring` JaCoCo: 100.00% instruction coverage, 94.59% branch coverage
