### PR TITLE
Clarify nullable NATS configuration contracts

### DIFF
--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsBinderServerConfiguredCondition.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsBinderServerConfiguredCondition.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nats.cloud.stream.binder;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+class NatsBinderServerConfiguredCondition implements Condition {
+    private static final String BINDER_SERVER_PROPERTY = "nats.spring.cloud.stream.binder.server";
+    private static final String GLOBAL_SERVER_PROPERTY = "nats.spring.server";
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return hasText(context, BINDER_SERVER_PROPERTY) || hasText(context, GLOBAL_SERVER_PROPERTY);
+    }
+
+    private static boolean hasText(ConditionContext context, String property) {
+        return StringUtils.hasText(context.getEnvironment().getProperty(property));
+    }
+}

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
@@ -45,6 +45,7 @@ import org.springframework.messaging.MessageHandler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A NATS channel binder provides a NATS connection to the code attached to it.
@@ -67,12 +68,13 @@ public class NatsChannelBinder extends
      * The NatsProperties are considered global and a backup. If a connection or error listener is provided it is used, otherwise a default logging listener is assigned to avoid
      * silent errors.
      *
-     * @param bindingProperties    extended properties for future use
-     * @param properties           primary properties
-     * @param natsProperties       backup global properties
-     * @param provisioningProvider provisioner for destination names
-     * @param connectionListener   custom connection listener
-     * @param errorListener        custom error listener
+     * @param bindingProperties    extended binding properties; must not be {@code null}
+     * @param properties           primary binder properties, or {@code null} when only global properties are available
+     * @param natsProperties       backup global properties, or {@code null} when only binder properties are available
+     * @param provisioningProvider provisioner for destination names; must not be {@code null}
+     * @param connectionListener   optional custom connection listener
+     * @param errorListener        optional custom error listener
+     * @throws NullPointerException if {@code bindingProperties} or {@code provisioningProvider} is {@code null}
      */
     public NatsChannelBinder(NatsExtendedBindingProperties bindingProperties,
                              @Nullable NatsBinderConfigurationProperties properties,
@@ -80,8 +82,9 @@ public class NatsChannelBinder extends
                              NatsChannelProvisioner provisioningProvider,
                              @Nullable ConnectionListener connectionListener,
                              @Nullable ErrorListener errorListener) {
-        super(headersToEmbed(properties), provisioningProvider);
-        this.bindingProperties = bindingProperties;
+        super(headersToEmbed(properties), Objects.requireNonNull(provisioningProvider,
+                "provisioningProvider must not be null"));
+        this.bindingProperties = Objects.requireNonNull(bindingProperties, "bindingProperties must not be null");
         this.properties = properties;
         this.natsProperties = natsProperties;
 
@@ -146,7 +149,7 @@ public class NatsChannelBinder extends
     }
 
     /**
-     * @return NATS connection
+     * @return NATS connection, or {@code null} when no server was configured or connection setup failed
      */
     @Nullable
     public Connection getConnection() {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.stream.binder.HeaderMode;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.integration.core.MessageProducer;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 
@@ -53,8 +54,11 @@ public class NatsChannelBinder extends
         implements ExtendedPropertiesBinder<MessageChannel, NatsConsumerProperties, NatsProducerProperties> {
     private static final Log logger = LogFactory.getLog(NatsChannelBinder.class);
     private final NatsExtendedBindingProperties bindingProperties;
+    @Nullable
     private NatsBinderConfigurationProperties properties;
+    @Nullable
     private NatsProperties natsProperties;
+    @Nullable
     private Connection connection;
 
     /**
@@ -71,11 +75,11 @@ public class NatsChannelBinder extends
      * @param errorListener        custom error listener
      */
     public NatsChannelBinder(NatsExtendedBindingProperties bindingProperties,
-                             NatsBinderConfigurationProperties properties,
-                             NatsProperties natsProperties,
+                             @Nullable NatsBinderConfigurationProperties properties,
+                             @Nullable NatsProperties natsProperties,
                              NatsChannelProvisioner provisioningProvider,
-                             ConnectionListener connectionListener,
-                             ErrorListener errorListener) {
+                             @Nullable ConnectionListener connectionListener,
+                             @Nullable ErrorListener errorListener) {
         super(headersToEmbed(properties), provisioningProvider);
         this.bindingProperties = bindingProperties;
         this.properties = properties;
@@ -103,7 +107,7 @@ public class NatsChannelBinder extends
                 builder = builder.connectionListener(connectionListener);
             } else {
                 builder = builder.connectionListener(new ConnectionListener() {
-                    public void connectionEvent(Connection conn, Events type) {
+                    public void connectionEvent(@Nullable Connection conn, Events type) {
                         logger.info("NATS connection status changed " + type);
                     }
                 });
@@ -114,17 +118,17 @@ public class NatsChannelBinder extends
             } else {
                 builder = builder.errorListener(new ErrorListener() {
                     @Override
-                    public void slowConsumerDetected(Connection conn, Consumer consumer) {
+                    public void slowConsumerDetected(@Nullable Connection conn, @Nullable Consumer consumer) {
                         logger.info("NATS connection slow consumer detected");
                     }
 
                     @Override
-                    public void exceptionOccurred(Connection conn, Exception exp) {
+                    public void exceptionOccurred(@Nullable Connection conn, Exception exp) {
                         logger.info("NATS connection exception occurred", exp);
                     }
 
                     @Override
-                    public void errorOccurred(Connection conn, String error) {
+                    public void errorOccurred(@Nullable Connection conn, String error) {
                         logger.info("NATS connection error occurred " + error);
                     }
                 });
@@ -144,6 +148,7 @@ public class NatsChannelBinder extends
     /**
      * @return NATS connection
      */
+    @Nullable
     public Connection getConnection() {
         return this.connection;
     }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinderConfiguration.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinderConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.lang.Nullable;
@@ -44,11 +45,13 @@ public class NatsChannelBinderConfiguration {
     /**
      * A custom connection listener, otherwise a simple logging default is used.
      */
+    @Nullable
     private final ConnectionListener connectionListener;
 
     /**
      * A custom error listener, otherwise a simple logging default is used.
      */
+    @Nullable
     private final ErrorListener errorListener;
 
     /**
@@ -105,9 +108,11 @@ public class NatsChannelBinderConfiguration {
     }
 
     @Bean
+    @Conditional(NatsBinderServerConfiguredCondition.class)
     /**
      * @return binder, based on the channel provisioner, using the properties associated with this configuration
      */
+    @Nullable
     public NatsChannelBinder natsBinder(NatsChannelProvisioner natsProvisioner) throws IOException, InterruptedException {
         NatsChannelBinder binder = new NatsChannelBinder(this.natsExtendedBindingProperties,
                 this.natsBinderConfigurationProperties,

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinderConfiguration.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinderConfiguration.java
@@ -34,13 +34,14 @@ import org.springframework.lang.Nullable;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
 
+/**
+ * Configuration for the NATS Spring Cloud Stream binder.
+ */
 @Configuration
 @Import({NatsAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class})
 @EnableConfigurationProperties({NatsExtendedBindingProperties.class, NatsBinderConfigurationProperties.class})
-/**
- * NatsChannelBinderConfiguration is used to parametrize a new NATS binder. This configuration provides custom error and connection listeners.
- */
 public class NatsChannelBinderConfiguration {
     /**
      * A custom connection listener, otherwise a simple logging default is used.
@@ -69,6 +70,16 @@ public class NatsChannelBinderConfiguration {
      */
     private final NatsExtendedBindingProperties natsExtendedBindingProperties;
 
+    /**
+     * Create binder configuration with optional listeners and required property objects.
+     *
+     * @param connectionListener optional custom connection listener
+     * @param errorListener optional custom error listener
+     * @param natsProperties global NATS properties; must not be {@code null}
+     * @param natsBinderConfigurationProperties binder-specific NATS properties; must not be {@code null}
+     * @param natsExtendedBindingProperties extended binding properties; must not be {@code null}
+     * @throws NullPointerException if any required property object is {@code null}
+     */
     public NatsChannelBinderConfiguration(@Nullable ConnectionListener connectionListener,
                                           @Nullable ErrorListener errorListener,
                                           NatsProperties natsProperties,
@@ -76,9 +87,11 @@ public class NatsChannelBinderConfiguration {
                                           NatsExtendedBindingProperties natsExtendedBindingProperties) {
         this.connectionListener = connectionListener;
         this.errorListener = errorListener;
-        this.natsProperties = natsProperties;
-        this.natsBinderConfigurationProperties = natsBinderConfigurationProperties;
-        this.natsExtendedBindingProperties = natsExtendedBindingProperties;
+        this.natsProperties = Objects.requireNonNull(natsProperties, "natsProperties must not be null");
+        this.natsBinderConfigurationProperties = Objects.requireNonNull(natsBinderConfigurationProperties,
+                "natsBinderConfigurationProperties must not be null");
+        this.natsExtendedBindingProperties = Objects.requireNonNull(natsExtendedBindingProperties,
+                "natsExtendedBindingProperties must not be null");
     }
 
     /**
@@ -99,33 +112,39 @@ public class NatsChannelBinderConfiguration {
         return this.natsProperties;
     }
 
-    @Bean
     /**
      * @return provisioner for NATS channels
      */
+    @Bean
     public NatsChannelProvisioner natsChannelProvisioner() {
         return new NatsChannelProvisioner();
     }
 
+    /**
+     * @param natsProvisioner provisioner for destination names; must not be {@code null}
+     * @return binder based on the channel provisioner and properties associated with this configuration
+     * @throws IOException if the binder cannot establish a NATS connection
+     * @throws InterruptedException if the NATS client is interrupted during connection setup
+     * @throws NullPointerException if {@code natsProvisioner} is {@code null}
+     */
     @Bean
     @Conditional(NatsBinderServerConfiguredCondition.class)
-    /**
-     * @return binder, based on the channel provisioner, using the properties associated with this configuration
-     */
-    @Nullable
     public NatsChannelBinder natsBinder(NatsChannelProvisioner natsProvisioner) throws IOException, InterruptedException {
         NatsChannelBinder binder = new NatsChannelBinder(this.natsExtendedBindingProperties,
                 this.natsBinderConfigurationProperties,
-                this.natsProperties, natsProvisioner,
+                this.natsProperties, Objects.requireNonNull(natsProvisioner, "natsProvisioner must not be null"),
                 this.connectionListener,
                 this.errorListener);
-        return binder.getConnection() != null ? binder : null;
+        if (binder.getConnection() == null) {
+            throw new IOException("NATS binder could not establish a connection");
+        }
+        return binder;
     }
 
-    @Bean
     /**
      * @return mapping between nats.spring.cloud.stream and nats.spring.cloud.stream
      */
+    @Bean
     public MappingsProvider natsExtendedPropertiesDefaultMappingsProvider() {
         return () -> Collections.singletonMap(
                 ConfigurationPropertyName.of("nats.spring.cloud.stream"),

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsConsumerDestination.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsConsumerDestination.java
@@ -18,6 +18,8 @@ package io.nats.cloud.stream.binder;
 
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 
+import java.util.Objects;
+
 /**
  * NatsConsumerDestinations use their name to determine the subject and queue group (if any) to listen to.
  */
@@ -27,10 +29,11 @@ public class NatsConsumerDestination implements ConsumerDestination {
     /**
      * Create a new consumer destination with the provided name.
      *
-     * @param name compound name from the provisioner containing the subject and optional queue group
+     * @param name compound name from the provisioner containing the subject and optional queue group; must not be {@code null}
+     * @throws NullPointerException if {@code name} is {@code null}
      */
     public NatsConsumerDestination(String name) {
-        this.name = name;
+        this.name = Objects.requireNonNull(name, "name must not be null");
     }
 
     @Override

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsJetStreamSupport.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsJetStreamSupport.java
@@ -23,6 +23,7 @@ import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
 import io.nats.cloud.stream.binder.properties.NatsProducerProperties;
+import org.springframework.lang.Nullable;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -37,7 +38,8 @@ class NatsJetStreamSupport {
     private NatsJetStreamSupport() {
     }
 
-    static String normalize(String value) {
+    @Nullable
+    static String normalize(@Nullable String value) {
         if (!hasText(value)) {
             return null;
         }
@@ -45,11 +47,11 @@ class NatsJetStreamSupport {
         return value.trim();
     }
 
-    static boolean hasText(String value) {
+    static boolean hasText(@Nullable String value) {
         return value != null && value.trim().length() > 0;
     }
 
-    static void provisionStream(Connection connection, String subject, NatsProducerProperties properties) {
+    static void provisionStream(@Nullable Connection connection, String subject, @Nullable NatsProducerProperties properties) {
         if (properties == null || !properties.isJetStream() || !properties.isProvisionStream()) {
             return;
         }
@@ -63,9 +65,9 @@ class NatsJetStreamSupport {
 
     private static void provisionStream(Connection connection,
                                         String subject,
-                                        String streamName,
-                                        StorageType storageType,
-                                        Integer streamReplicas) {
+                                        @Nullable String streamName,
+                                        @Nullable StorageType storageType,
+                                        @Nullable Integer streamReplicas) {
         String stream = normalize(streamName);
         String streamSubject = normalize(subject);
         if (!hasText(stream)) {
@@ -95,8 +97,8 @@ class NatsJetStreamSupport {
     private static void addStream(JetStreamManagement management,
                                   String stream,
                                   String subject,
-                                  StorageType storageType,
-                                  Integer streamReplicas)
+                                  @Nullable StorageType storageType,
+                                  @Nullable Integer streamReplicas)
             throws IOException, JetStreamApiException {
         try {
             management.addStream(newStreamConfiguration(stream, subject, storageType, streamReplicas));
@@ -125,6 +127,7 @@ class NatsJetStreamSupport {
         return builder.build();
     }
 
+    @Nullable
     private static StreamInfo streamInfoOrNull(JetStreamManagement management, String stream)
             throws IOException, JetStreamApiException {
         try {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageHandler.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageHandler.java
@@ -32,6 +32,7 @@ import org.springframework.messaging.MessageHeaders;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 /**
  * NatsMessageHandlers implement the standard message handling pattern. byte[], ByteBuffer and Strings are supported, where
@@ -53,8 +54,9 @@ public class NatsMessageHandler extends AbstractMessageHandler {
     /**
      * Create a handler with a specific, unchanging subject, and a NATS connection.
      *
-     * @param subject where to send message to by default
-     * @param nc      NATS connection
+     * @param subject subject to publish messages to by default; must not be {@code null}
+     * @param nc      NATS connection, or {@code null} when connection setup failed
+     * @throws NullPointerException if {@code subject} is {@code null}
      */
     public NatsMessageHandler(String subject, @Nullable Connection nc) {
         this(subject, nc, true);
@@ -63,9 +65,10 @@ public class NatsMessageHandler extends AbstractMessageHandler {
     /**
      * Create a handler with a specific, unchanging subject, a NATS connection, and header mode.
      *
-     * @param subject        where to send message to by default
-     * @param nc             NATS connection
+     * @param subject        subject to publish messages to by default; must not be {@code null}
+     * @param nc             NATS connection, or {@code null} when connection setup failed
      * @param publishHeaders whether Spring headers should be published as native NATS headers
+     * @throws NullPointerException if {@code subject} is {@code null}
      */
     public NatsMessageHandler(String subject, @Nullable Connection nc, boolean publishHeaders) {
         this(subject, nc, publishHeaders, false, null);
@@ -74,15 +77,16 @@ public class NatsMessageHandler extends AbstractMessageHandler {
     /**
      * Create a handler with a specific, unchanging subject, a NATS connection, header mode, and JetStream mode.
      *
-     * @param subject        where to send message to by default
-     * @param nc             NATS connection
+     * @param subject        subject to publish messages to by default; must not be {@code null}
+     * @param nc             NATS connection, or {@code null} when connection setup failed
      * @param publishHeaders whether Spring headers should be published as native NATS headers
      * @param jetStream      whether messages should be published through JetStream
-     * @param streamName     optional JetStream stream name
+     * @param streamName     optional JetStream stream name; {@code null} lets the client resolve the target stream
+     * @throws NullPointerException if {@code subject} is {@code null}
      */
     public NatsMessageHandler(String subject, @Nullable Connection nc, boolean publishHeaders, boolean jetStream,
                               @Nullable String streamName) {
-        this.subject = subject;
+        this.subject = Objects.requireNonNull(subject, "subject must not be null");
         this.connection = nc;
         this.publishHeaders = publishHeaders;
         this.jetStream = jetStream;
@@ -90,12 +94,12 @@ public class NatsMessageHandler extends AbstractMessageHandler {
         this.jetStreamContext = jetStreamContext(nc, jetStream);
     }
 
-    @Override
     /**
      * Given a message, take the payload and publish it on the handlers subject.
-     * If the message contains a MessageHeaders.REPLY_CHANNEL header, it is passed on to allow taking advantage of build-in request/reply handling
+     * If the message contains a MessageHeaders.REPLY_CHANNEL header, it is passed on to allow taking advantage of built-in request/reply handling
      * in Spring Integration / Spring Cloud Stream.
      */
+    @Override
     protected void handleMessageInternal(Message<?> message) {
         Object payload = message.getPayload();
         byte[] bytes = null;
@@ -115,24 +119,26 @@ public class NatsMessageHandler extends AbstractMessageHandler {
             return;
         }
 
-        if (this.connection != null) {
+        Connection nc = this.connection;
+        if (nc != null) {
             final Object replyChannel = message.getHeaders().get(MessageHeaders.REPLY_CHANNEL);
             final String replyTo = replyChannel != null ? replyChannel.toString() : null;
             Headers headers = this.publishHeaders ? NatsHeaderMapper.fromSpringHeaders(message.getHeaders()) : null;
-            publishMessage(message, bytes, replyTo, headers);
+            publishMessage(nc, message, bytes, replyTo, headers);
         }
     }
 
-    private void publishMessage(Message<?> message, byte[] bytes, @Nullable String replyTo, @Nullable Headers headers) {
+    private void publishMessage(Connection nc, Message<?> message, byte[] bytes, @Nullable String replyTo,
+                                @Nullable Headers headers) {
         if (this.jetStream) {
             publishJetStreamMessage(message, bytes, replyTo, headers);
             return;
         }
 
         if (headers == null) {
-            this.connection.publish(this.subject, replyTo, bytes);
+            nc.publish(this.subject, replyTo, bytes);
         } else {
-            this.connection.publish(this.subject, replyTo, headers, bytes);
+            nc.publish(this.subject, replyTo, headers, bytes);
         }
     }
 
@@ -142,8 +148,12 @@ public class NatsMessageHandler extends AbstractMessageHandler {
             throw new MessageHandlingException(message, "JetStream publishing does not support reply channels");
         }
 
+        JetStream js = this.jetStreamContext;
+        if (js == null) {
+            throw new MessageHandlingException(message, "JetStream context is not available");
+        }
+
         try {
-            JetStream js = this.jetStreamContext;
             PublishOptions publishOptions = publishOptions();
             if (headers == null) {
                 if (publishOptions == null) {

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageHandler.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageHandler.java
@@ -24,6 +24,7 @@ import io.nats.client.impl.Headers;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.integration.handler.AbstractMessageHandler;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
@@ -40,10 +41,13 @@ public class NatsMessageHandler extends AbstractMessageHandler {
     private static final Log logger = LogFactory.getLog(NatsMessageHandler.class);
 
     private String subject;
+    @Nullable
     private Connection connection;
     private boolean publishHeaders;
     private boolean jetStream;
+    @Nullable
     private String streamName;
+    @Nullable
     private JetStream jetStreamContext;
 
     /**
@@ -52,7 +56,7 @@ public class NatsMessageHandler extends AbstractMessageHandler {
      * @param subject where to send message to by default
      * @param nc      NATS connection
      */
-    public NatsMessageHandler(String subject, Connection nc) {
+    public NatsMessageHandler(String subject, @Nullable Connection nc) {
         this(subject, nc, true);
     }
 
@@ -63,7 +67,7 @@ public class NatsMessageHandler extends AbstractMessageHandler {
      * @param nc             NATS connection
      * @param publishHeaders whether Spring headers should be published as native NATS headers
      */
-    public NatsMessageHandler(String subject, Connection nc, boolean publishHeaders) {
+    public NatsMessageHandler(String subject, @Nullable Connection nc, boolean publishHeaders) {
         this(subject, nc, publishHeaders, false, null);
     }
 
@@ -76,7 +80,8 @@ public class NatsMessageHandler extends AbstractMessageHandler {
      * @param jetStream      whether messages should be published through JetStream
      * @param streamName     optional JetStream stream name
      */
-    public NatsMessageHandler(String subject, Connection nc, boolean publishHeaders, boolean jetStream, String streamName) {
+    public NatsMessageHandler(String subject, @Nullable Connection nc, boolean publishHeaders, boolean jetStream,
+                              @Nullable String streamName) {
         this.subject = subject;
         this.connection = nc;
         this.publishHeaders = publishHeaders;
@@ -118,7 +123,7 @@ public class NatsMessageHandler extends AbstractMessageHandler {
         }
     }
 
-    private void publishMessage(Message<?> message, byte[] bytes, String replyTo, Headers headers) {
+    private void publishMessage(Message<?> message, byte[] bytes, @Nullable String replyTo, @Nullable Headers headers) {
         if (this.jetStream) {
             publishJetStreamMessage(message, bytes, replyTo, headers);
             return;
@@ -131,7 +136,8 @@ public class NatsMessageHandler extends AbstractMessageHandler {
         }
     }
 
-    private void publishJetStreamMessage(Message<?> message, byte[] bytes, String replyTo, Headers headers) {
+    private void publishJetStreamMessage(Message<?> message, byte[] bytes, @Nullable String replyTo,
+                                         @Nullable Headers headers) {
         if (replyTo != null) {
             throw new MessageHandlingException(message, "JetStream publishing does not support reply channels");
         }
@@ -156,6 +162,7 @@ public class NatsMessageHandler extends AbstractMessageHandler {
         }
     }
 
+    @Nullable
     private PublishOptions publishOptions() {
         if (!NatsJetStreamSupport.hasText(this.streamName)) {
             return null;
@@ -166,7 +173,8 @@ public class NatsMessageHandler extends AbstractMessageHandler {
                 .build();
     }
 
-    private static JetStream jetStreamContext(Connection nc, boolean jetStream) {
+    @Nullable
+    private static JetStream jetStreamContext(@Nullable Connection nc, boolean jetStream) {
         if (!jetStream || nc == null) {
             return null;
         }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.core.MessageProducer;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -45,13 +46,16 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
 
     private NatsConsumerDestination destination;
     private Connection connection;
+    @Nullable
     private MessageChannel output;
     private AtomicReference<Dispatcher> dispatcher = new AtomicReference<>();
     private AtomicReference<io.nats.client.MessageConsumer> jetStreamConsumer = new AtomicReference<>();
     private boolean includeNativeHeaders;
     private boolean markNativeHeadersPresent;
     private boolean jetStream;
+    @Nullable
     private String streamName;
+    @Nullable
     private String consumerName;
 
     /**
@@ -91,7 +95,7 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
      */
     public NatsMessageProducer(NatsConsumerDestination destination, Connection nc,
                                boolean includeNativeHeaders, boolean markNativeHeadersPresent,
-                               boolean jetStream, String streamName, String consumerName) {
+                               boolean jetStream, @Nullable String streamName, @Nullable String consumerName) {
         this.destination = destination;
         this.connection = nc;
         this.includeNativeHeaders = includeNativeHeaders;
@@ -102,6 +106,7 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
     }
 
     @Override
+    @Nullable
     public MessageChannel getOutputChannel() {
         return this.output;
     }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageProducer.java
@@ -31,6 +31,7 @@ import org.springframework.messaging.support.GenericMessage;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -45,6 +46,7 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
     public static final String SUBJECT = "subject";
 
     private NatsConsumerDestination destination;
+    @Nullable
     private Connection connection;
     @Nullable
     private MessageChannel output;
@@ -62,22 +64,24 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
      * Create a message producer. Once started the producer will use a dispatcher, and the associated thread, to
      * listen for and handle incoming messages.
      *
-     * @param destination where to subscribe
-     * @param nc          NATS connection
+     * @param destination destination to subscribe to; must not be {@code null}
+     * @param nc          NATS connection, or {@code null} when connection setup failed
+     * @throws NullPointerException if {@code destination} is {@code null}
      */
-    public NatsMessageProducer(NatsConsumerDestination destination, Connection nc) {
+    public NatsMessageProducer(NatsConsumerDestination destination, @Nullable Connection nc) {
         this(destination, nc, true, true);
     }
 
     /**
      * Create a message producer with explicit native header behavior.
      *
-     * @param destination              where to subscribe
-     * @param nc                       NATS connection
+     * @param destination              destination to subscribe to; must not be {@code null}
+     * @param nc                       NATS connection, or {@code null} when connection setup failed
      * @param includeNativeHeaders     whether native NATS headers should be copied to Spring headers
      * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
+     * @throws NullPointerException if {@code destination} is {@code null}
      */
-    public NatsMessageProducer(NatsConsumerDestination destination, Connection nc,
+    public NatsMessageProducer(NatsConsumerDestination destination, @Nullable Connection nc,
                                boolean includeNativeHeaders, boolean markNativeHeadersPresent) {
         this(destination, nc, includeNativeHeaders, markNativeHeadersPresent, false, null, null);
     }
@@ -85,18 +89,19 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
     /**
      * Create a message producer with explicit native header and JetStream behavior.
      *
-     * @param destination              where to subscribe
-     * @param nc                       NATS connection
+     * @param destination              destination to subscribe to; must not be {@code null}
+     * @param nc                       NATS connection, or {@code null} when connection setup failed
      * @param includeNativeHeaders     whether native NATS headers should be copied to Spring headers
      * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
      * @param jetStream                whether messages should be consumed through JetStream
-     * @param streamName               optional JetStream stream name
-     * @param consumerName             optional JetStream consumer name
+     * @param streamName               optional JetStream stream name; required before start when JetStream mode is enabled
+     * @param consumerName             optional JetStream consumer name; required before start when JetStream mode is enabled and no consumer group exists
+     * @throws NullPointerException if {@code destination} is {@code null}
      */
-    public NatsMessageProducer(NatsConsumerDestination destination, Connection nc,
+    public NatsMessageProducer(NatsConsumerDestination destination, @Nullable Connection nc,
                                boolean includeNativeHeaders, boolean markNativeHeadersPresent,
                                boolean jetStream, @Nullable String streamName, @Nullable String consumerName) {
-        this.destination = destination;
+        this.destination = Objects.requireNonNull(destination, "destination must not be null");
         this.connection = nc;
         this.includeNativeHeaders = includeNativeHeaders;
         this.markNativeHeadersPresent = markNativeHeadersPresent;
@@ -105,6 +110,9 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
         this.consumerName = NatsJetStreamSupport.normalize(consumerName);
     }
 
+    /**
+     * @return output channel receiving Spring messages, or {@code null} when none has been configured
+     */
     @Override
     @Nullable
     public MessageChannel getOutputChannel() {
@@ -127,12 +135,19 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
             return;
         }
 
-        if (this.jetStream) {
-            startJetStream();
+        Connection nc = this.connection;
+        if (nc == null) {
+            logger.warn("cannot start NATS message producer, no connection available for "
+                    + this.destination.getName());
             return;
         }
 
-        Dispatcher dispatcher = this.connection.createDispatcher(this::handleIncomingMessage);
+        if (this.jetStream) {
+            startJetStream(nc);
+            return;
+        }
+
+        Dispatcher dispatcher = nc.createDispatcher(this::handleIncomingMessage);
         this.dispatcher.set(dispatcher);
 
         String sub = this.destination.getSubject();
@@ -145,7 +160,7 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
         }
     }
 
-    private void startJetStream() {
+    private void startJetStream(Connection nc) {
         String sub = this.destination.getSubject();
         String queue = this.destination.getQueueGroup();
         String consumer = NatsJetStreamSupport.hasText(this.consumerName)
@@ -159,15 +174,15 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
             throw new IllegalStateException("NATS JetStream consumers require consumer-name or a consumer group");
         }
 
-        Dispatcher dispatcher = this.connection.createDispatcher();
+        Dispatcher dispatcher = nc.createDispatcher();
         this.dispatcher.set(dispatcher);
 
         try {
-            ConsumerContext consumerContext = this.connection.jetStream()
+            ConsumerContext consumerContext = nc.jetStream()
                     .getConsumerContext(this.streamName, consumer);
             this.jetStreamConsumer.set(consumerContext.consume(dispatcher, this::handleIncomingMessage));
         } catch (IOException | JetStreamApiException | IllegalArgumentException exp) {
-            this.connection.closeDispatcher(dispatcher);
+            nc.closeDispatcher(dispatcher);
             this.dispatcher.compareAndSet(dispatcher, null);
             throw new IllegalStateException("Failed to subscribe to NATS JetStream subject " + sub, exp);
         }
@@ -214,6 +229,9 @@ public class NatsMessageProducer implements MessageProducer, Lifecycle {
         if (consumer != null) {
             consumer.stop();
         }
-        this.connection.closeDispatcher(dispatcher);
+        Connection nc = this.connection;
+        if (nc != null) {
+            nc.closeDispatcher(dispatcher);
+        }
     }
 }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
@@ -30,6 +30,7 @@ import org.springframework.context.Lifecycle;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.endpoint.AbstractMessageSource;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.support.GenericMessage;
 
 import java.io.IOException;
@@ -52,7 +53,9 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     private boolean includeNativeHeaders;
     private boolean markNativeHeadersPresent;
     private boolean jetStream;
+    @Nullable
     private String streamName;
+    @Nullable
     private String consumerName;
 
     /**
@@ -93,7 +96,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
      */
     public NatsMessageSource(NatsConsumerDestination destination, Connection nc,
                              boolean includeNativeHeaders, boolean markNativeHeadersPresent,
-                             boolean jetStream, String streamName, String consumerName) {
+                             boolean jetStream, @Nullable String streamName, @Nullable String consumerName) {
         this.destination = destination;
         this.connection = nc;
         this.includeNativeHeaders = includeNativeHeaders;
@@ -104,6 +107,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     }
 
     @Override
+    @Nullable
     protected Object doReceive() {
         ConsumerContext context = this.consumerContext.get();
         if (!this.jetStream && this.sub == null) {
@@ -211,6 +215,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
         return "nats:message-source";
     }
 
+    @Nullable
     private Message receiveJetStreamMessage(ConsumerContext context)
             throws IOException, JetStreamApiException, InterruptedException, JetStreamStatusCheckedException {
         FetchConsumer consumer = context.fetch(FetchConsumeOptions.builder()
@@ -229,7 +234,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
         }
     }
 
-    private static void closeFetchConsumer(FetchConsumer consumer) {
+    private static void closeFetchConsumer(@Nullable FetchConsumer consumer) {
         if (consumer == null) {
             return;
         }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsMessageSource.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.support.GenericMessage;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,7 +47,9 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     private static final Log logger = LogFactory.getLog(NatsMessageSource.class);
 
     private NatsConsumerDestination destination;
+    @Nullable
     private Connection connection;
+    @Nullable
     private Subscription sub;
     private AtomicReference<ConsumerContext> consumerContext = new AtomicReference<>();
     private AtomicReference<FetchConsumer> fetchConsumer = new AtomicReference<>();
@@ -63,22 +66,24 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
      * Calls to doReceive result in a nextMessage call at the NATS level. Core NATS uses a
      * subscription, while JetStream uses a named ConsumerContext.
      *
-     * @param destination where to subscribe
-     * @param nc          NATS connection
+     * @param destination destination to subscribe to; must not be {@code null}
+     * @param nc          NATS connection, or {@code null} when connection setup failed
+     * @throws NullPointerException if {@code destination} is {@code null}
      */
-    public NatsMessageSource(NatsConsumerDestination destination, Connection nc) {
+    public NatsMessageSource(NatsConsumerDestination destination, @Nullable Connection nc) {
         this(destination, nc, true, true);
     }
 
     /**
      * Create a message source with explicit native header behavior.
      *
-     * @param destination              where to subscribe
-     * @param nc                       NATS connection
+     * @param destination              destination to subscribe to; must not be {@code null}
+     * @param nc                       NATS connection, or {@code null} when connection setup failed
      * @param includeNativeHeaders     whether native NATS headers should be copied to Spring headers
      * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
+     * @throws NullPointerException if {@code destination} is {@code null}
      */
-    public NatsMessageSource(NatsConsumerDestination destination, Connection nc,
+    public NatsMessageSource(NatsConsumerDestination destination, @Nullable Connection nc,
                              boolean includeNativeHeaders, boolean markNativeHeadersPresent) {
         this(destination, nc, includeNativeHeaders, markNativeHeadersPresent, false, null, null);
     }
@@ -86,18 +91,19 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
     /**
      * Create a message source with explicit native header and JetStream behavior.
      *
-     * @param destination              where to subscribe
-     * @param nc                       NATS connection
+     * @param destination              destination to subscribe to; must not be {@code null}
+     * @param nc                       NATS connection, or {@code null} when connection setup failed
      * @param includeNativeHeaders     whether native NATS headers should be copied to Spring headers
      * @param markNativeHeadersPresent whether Spring Cloud Stream should be told native headers were present
      * @param jetStream                whether messages should be consumed through JetStream
-     * @param streamName               optional JetStream stream name
-     * @param consumerName             optional JetStream consumer name
+     * @param streamName               optional JetStream stream name; required before start when JetStream mode is enabled
+     * @param consumerName             optional JetStream consumer name; required before start when JetStream mode is enabled and no consumer group exists
+     * @throws NullPointerException if {@code destination} is {@code null}
      */
-    public NatsMessageSource(NatsConsumerDestination destination, Connection nc,
+    public NatsMessageSource(NatsConsumerDestination destination, @Nullable Connection nc,
                              boolean includeNativeHeaders, boolean markNativeHeadersPresent,
                              boolean jetStream, @Nullable String streamName, @Nullable String consumerName) {
-        this.destination = destination;
+        this.destination = Objects.requireNonNull(destination, "destination must not be null");
         this.connection = nc;
         this.includeNativeHeaders = includeNativeHeaders;
         this.markNativeHeadersPresent = markNativeHeadersPresent;
@@ -106,11 +112,15 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
         this.consumerName = NatsJetStreamSupport.normalize(consumerName);
     }
 
+    /**
+     * @return a Spring message for the next available NATS message, or {@code null} when no message is available
+     */
     @Override
     @Nullable
     protected Object doReceive() {
         ConsumerContext context = this.consumerContext.get();
-        if (!this.jetStream && this.sub == null) {
+        Subscription subscription = this.sub;
+        if (!this.jetStream && subscription == null) {
             return null;
         }
         if (this.jetStream && context == null) {
@@ -122,7 +132,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
             if (this.jetStream) {
                 m = receiveJetStreamMessage(context);
             } else {
-                m = this.sub.nextMessage(Duration.ZERO);
+                m = subscription.nextMessage(Duration.ZERO);
             }
 
             if (this.jetStream && this.consumerContext.get() != context) {
@@ -161,22 +171,29 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
             return;
         }
 
+        Connection nc = this.connection;
+        if (nc == null) {
+            logger.warn("cannot start NATS message source, no connection available for "
+                    + this.destination.getName());
+            return;
+        }
+
         String sub = this.destination.getSubject();
         String queue = this.destination.getQueueGroup();
 
         if (this.jetStream) {
-            startJetStream(sub, queue);
+            startJetStream(nc, sub, queue);
             return;
         }
 
         if (queue != null && queue.length() > 0) {
-            this.sub = this.connection.subscribe(sub, queue);
+            this.sub = nc.subscribe(sub, queue);
         } else {
-            this.sub = this.connection.subscribe(sub);
+            this.sub = nc.subscribe(sub);
         }
     }
 
-    private void startJetStream(String sub, String queue) {
+    private void startJetStream(Connection nc, String sub, String queue) {
         String consumer = NatsJetStreamSupport.hasText(this.consumerName)
                 ? this.consumerName
                 : NatsJetStreamSupport.normalize(queue);
@@ -188,7 +205,7 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
         }
 
         try {
-            this.consumerContext.set(this.connection.jetStream().getConsumerContext(this.streamName, consumer));
+            this.consumerContext.set(nc.jetStream().getConsumerContext(this.streamName, consumer));
         } catch (IOException | JetStreamApiException | IllegalArgumentException exp) {
             throw new IllegalStateException("Failed to subscribe to NATS JetStream subject " + sub, exp);
         }
@@ -202,11 +219,12 @@ public class NatsMessageSource extends AbstractMessageSource<Object> implements 
             return;
         }
 
-        if (this.sub == null) {
+        Subscription subscription = this.sub;
+        if (subscription == null) {
             return;
         }
 
-        this.sub.unsubscribe();
+        subscription.unsubscribe();
         this.sub = null;
     }
 

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsProducerDestination.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsProducerDestination.java
@@ -18,16 +18,24 @@ package io.nats.cloud.stream.binder;
 
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 
+import java.util.Objects;
+
 /**
  * NATS uses subjects for sending and receiving. While partitions are not used
- * this class can generate a patition-based name for compatibility with the binder
+ * this class can generate a partition-based name for compatibility with the binder
  * API.
  */
 public class NatsProducerDestination implements ProducerDestination {
     private String name;
 
+    /**
+     * Create a new producer destination with the provided subject name.
+     *
+     * @param name subject name; must not be {@code null}
+     * @throws NullPointerException if {@code name} is {@code null}
+     */
     public NatsProducerDestination(String name) {
-        this.name = name;
+        this.name = Objects.requireNonNull(name, "name must not be null");
     }
 
     @Override

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsBinderConfigurationProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsBinderConfigurationProperties.java
@@ -22,16 +22,23 @@ import org.springframework.lang.Nullable;
 
 @ConfigurationProperties(prefix = "nats.spring.cloud.stream.binder")
 public class NatsBinderConfigurationProperties extends NatsConnectionProperties {
+    @Nullable
     private String[] headersToEmbed;
 
     public NatsBinderConfigurationProperties() {
     }
 
+    /**
+     * @return custom Spring header names to embed when embedded headers are used, or {@code null} to use Spring Cloud Stream defaults
+     */
     @Nullable
     public String[] getHeadersToEmbed() {
         return this.headersToEmbed;
     }
 
+    /**
+     * @param headersToEmbed custom Spring header names to embed, or {@code null} to use Spring Cloud Stream defaults
+     */
     public void setHeadersToEmbed(@Nullable String[] headersToEmbed) {
         this.headersToEmbed = headersToEmbed;
     }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsBinderConfigurationProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsBinderConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.nats.cloud.stream.binder.properties;
 
 import io.nats.spring.boot.autoconfigure.NatsConnectionProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
 
 @ConfigurationProperties(prefix = "nats.spring.cloud.stream.binder")
 public class NatsBinderConfigurationProperties extends NatsConnectionProperties {
@@ -26,11 +27,12 @@ public class NatsBinderConfigurationProperties extends NatsConnectionProperties 
     public NatsBinderConfigurationProperties() {
     }
 
+    @Nullable
     public String[] getHeadersToEmbed() {
         return this.headersToEmbed;
     }
 
-    public void setHeadersToEmbed(String[] headersToEmbed) {
+    public void setHeadersToEmbed(@Nullable String[] headersToEmbed) {
         this.headersToEmbed = headersToEmbed;
     }
 }

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsConsumerProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsConsumerProperties.java
@@ -16,6 +16,8 @@
 
 package io.nats.cloud.stream.binder.properties;
 
+import org.springframework.lang.Nullable;
+
 public class NatsConsumerProperties {
     private boolean jetStream;
     private String streamName;
@@ -38,6 +40,7 @@ public class NatsConsumerProperties {
     /**
      * @return optional JetStream stream name used for subscriptions
      */
+    @Nullable
     public String getStreamName() {
         return this.streamName;
     }
@@ -45,13 +48,14 @@ public class NatsConsumerProperties {
     /**
      * @param streamName optional JetStream stream name used for subscriptions
      */
-    public void setStreamName(String streamName) {
+    public void setStreamName(@Nullable String streamName) {
         this.streamName = streamName;
     }
 
     /**
      * @return optional JetStream consumer name used for subscriptions
      */
+    @Nullable
     public String getConsumerName() {
         return this.consumerName;
     }
@@ -59,7 +63,7 @@ public class NatsConsumerProperties {
     /**
      * @param consumerName optional JetStream consumer name used for subscriptions
      */
-    public void setConsumerName(String consumerName) {
+    public void setConsumerName(@Nullable String consumerName) {
         this.consumerName = consumerName;
     }
 

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsConsumerProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsConsumerProperties.java
@@ -20,7 +20,9 @@ import org.springframework.lang.Nullable;
 
 public class NatsConsumerProperties {
     private boolean jetStream;
+    @Nullable
     private String streamName;
+    @Nullable
     private String consumerName;
 
     /**
@@ -38,7 +40,7 @@ public class NatsConsumerProperties {
     }
 
     /**
-     * @return optional JetStream stream name used for subscriptions
+     * @return JetStream stream name used for subscriptions, or {@code null} when no stream name was configured
      */
     @Nullable
     public String getStreamName() {
@@ -46,14 +48,14 @@ public class NatsConsumerProperties {
     }
 
     /**
-     * @param streamName optional JetStream stream name used for subscriptions
+     * @param streamName JetStream stream name used for subscriptions, or {@code null} to leave it unset
      */
     public void setStreamName(@Nullable String streamName) {
         this.streamName = streamName;
     }
 
     /**
-     * @return optional JetStream consumer name used for subscriptions
+     * @return JetStream consumer name used for subscriptions, or {@code null} when no consumer name was configured
      */
     @Nullable
     public String getConsumerName() {
@@ -61,7 +63,7 @@ public class NatsConsumerProperties {
     }
 
     /**
-     * @param consumerName optional JetStream consumer name used for subscriptions
+     * @param consumerName JetStream consumer name used for subscriptions, or {@code null} to leave it unset
      */
     public void setConsumerName(@Nullable String consumerName) {
         this.consumerName = consumerName;

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsProducerProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsProducerProperties.java
@@ -21,9 +21,12 @@ import org.springframework.lang.Nullable;
 
 public class NatsProducerProperties {
     private boolean jetStream;
+    @Nullable
     private String streamName;
     private boolean provisionStream;
+    @Nullable
     private StorageType streamStorageType;
+    @Nullable
     private Integer streamReplicas;
 
     /**
@@ -41,7 +44,7 @@ public class NatsProducerProperties {
     }
 
     /**
-     * @return optional JetStream stream name used for publish acknowledgements
+     * @return JetStream stream name used for publish acknowledgements, or {@code null} when no stream name was configured
      */
     @Nullable
     public String getStreamName() {
@@ -49,7 +52,7 @@ public class NatsProducerProperties {
     }
 
     /**
-     * @param streamName optional JetStream stream name used for publish acknowledgements
+     * @param streamName JetStream stream name used for publish acknowledgements, or {@code null} to leave it unset
      */
     public void setStreamName(@Nullable String streamName) {
         this.streamName = streamName;
@@ -70,7 +73,7 @@ public class NatsProducerProperties {
     }
 
     /**
-     * @return optional storage type used when a missing JetStream stream is provisioned
+     * @return storage type used when a missing JetStream stream is provisioned, or {@code null} to use the NATS client default
      */
     @Nullable
     public StorageType getStreamStorageType() {
@@ -78,14 +81,14 @@ public class NatsProducerProperties {
     }
 
     /**
-     * @param streamStorageType optional storage type used when a missing JetStream stream is provisioned
+     * @param streamStorageType storage type used when a missing JetStream stream is provisioned, or {@code null} to use the NATS client default
      */
     public void setStreamStorageType(@Nullable StorageType streamStorageType) {
         this.streamStorageType = streamStorageType;
     }
 
     /**
-     * @return optional replica count used when a missing JetStream stream is provisioned
+     * @return replica count used when a missing JetStream stream is provisioned, or {@code null} to use the NATS client default
      */
     @Nullable
     public Integer getStreamReplicas() {
@@ -93,7 +96,7 @@ public class NatsProducerProperties {
     }
 
     /**
-     * @param streamReplicas optional replica count used when a missing JetStream stream is provisioned
+     * @param streamReplicas replica count used when a missing JetStream stream is provisioned, or {@code null} to use the NATS client default
      */
     public void setStreamReplicas(@Nullable Integer streamReplicas) {
         this.streamReplicas = streamReplicas;

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsProducerProperties.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/properties/NatsProducerProperties.java
@@ -17,6 +17,7 @@
 package io.nats.cloud.stream.binder.properties;
 
 import io.nats.client.api.StorageType;
+import org.springframework.lang.Nullable;
 
 public class NatsProducerProperties {
     private boolean jetStream;
@@ -42,6 +43,7 @@ public class NatsProducerProperties {
     /**
      * @return optional JetStream stream name used for publish acknowledgements
      */
+    @Nullable
     public String getStreamName() {
         return this.streamName;
     }
@@ -49,7 +51,7 @@ public class NatsProducerProperties {
     /**
      * @param streamName optional JetStream stream name used for publish acknowledgements
      */
-    public void setStreamName(String streamName) {
+    public void setStreamName(@Nullable String streamName) {
         this.streamName = streamName;
     }
 
@@ -70,6 +72,7 @@ public class NatsProducerProperties {
     /**
      * @return optional storage type used when a missing JetStream stream is provisioned
      */
+    @Nullable
     public StorageType getStreamStorageType() {
         return this.streamStorageType;
     }
@@ -77,13 +80,14 @@ public class NatsProducerProperties {
     /**
      * @param streamStorageType optional storage type used when a missing JetStream stream is provisioned
      */
-    public void setStreamStorageType(StorageType streamStorageType) {
+    public void setStreamStorageType(@Nullable StorageType streamStorageType) {
         this.streamStorageType = streamStorageType;
     }
 
     /**
      * @return optional replica count used when a missing JetStream stream is provisioned
      */
+    @Nullable
     public Integer getStreamReplicas() {
         return this.streamReplicas;
     }
@@ -91,7 +95,7 @@ public class NatsProducerProperties {
     /**
      * @param streamReplicas optional replica count used when a missing JetStream stream is provisioned
      */
-    public void setStreamReplicas(Integer streamReplicas) {
+    public void setStreamReplicas(@Nullable Integer streamReplicas) {
         this.streamReplicas = streamReplicas;
     }
 }

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
@@ -138,7 +138,7 @@ class BinderTests {
     }
 
     @Test
-    void createBinderWithoutServerProperties() throws IOException, InterruptedException {
+    void createBinderWithoutServerPropertiesFailsExplicitly() {
         NatsChannelBinderConfiguration config = new NatsChannelBinderConfiguration(
                 null,
                 null,
@@ -147,7 +147,9 @@ class BinderTests {
                 new NatsExtendedBindingProperties());
         NatsChannelProvisioner provisioner = config.natsChannelProvisioner();
 
-        assertThat(config.natsBinder(provisioner)).isNull();
+        assertThatThrownBy(() -> config.natsBinder(provisioner))
+                .isInstanceOf(IOException.class)
+                .hasMessage("NATS binder could not establish a connection");
     }
 
     @Test
@@ -161,6 +163,29 @@ class BinderTests {
                 null);
 
         assertThat(binder.getConnection()).isNull();
+    }
+
+    @Test
+    void createBinderRejectsMissingRequiredCollaborators() {
+        assertThatThrownBy(() -> new NatsChannelBinder(
+                null,
+                null,
+                null,
+                new NatsChannelProvisioner(),
+                null,
+                null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("bindingProperties must not be null");
+
+        assertThatThrownBy(() -> new NatsChannelBinder(
+                new NatsExtendedBindingProperties(),
+                null,
+                null,
+                null,
+                null,
+                null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("provisioningProvider must not be null");
     }
 
     @Test
@@ -201,6 +226,36 @@ class BinderTests {
         assertThat(config.getNatsProperties()).isSameAs(natsProperties);
         assertThat(config.natsChannelProvisioner()).isNotNull();
         assertThat(mappings).containsEntry(streamPrefix, streamPrefix);
+    }
+
+    @Test
+    void binderConfigurationRejectsMissingRequiredPropertyObjects() {
+        assertThatThrownBy(() -> new NatsChannelBinderConfiguration(
+                null,
+                null,
+                null,
+                new NatsBinderConfigurationProperties(),
+                new NatsExtendedBindingProperties()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("natsProperties must not be null");
+
+        assertThatThrownBy(() -> new NatsChannelBinderConfiguration(
+                null,
+                null,
+                new NatsProperties(),
+                null,
+                new NatsExtendedBindingProperties()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("natsBinderConfigurationProperties must not be null");
+
+        assertThatThrownBy(() -> new NatsChannelBinderConfiguration(
+                null,
+                null,
+                new NatsProperties(),
+                new NatsBinderConfigurationProperties(),
+                null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("natsExtendedBindingProperties must not be null");
     }
 
     @Test
@@ -270,7 +325,7 @@ class BinderTests {
     }
 
     @Test
-    void createBinderReturnsNullWhenAuthenticationFails() throws IOException, InterruptedException {
+    void createBinderFailsExplicitlyWhenAuthenticationFails() throws IOException, InterruptedException {
         try (NatsBinderTestServer ts = new NatsBinderTestServer(new String[]{"--auth", "secret"}, false)) {
             NatsBinderConfigurationProperties binderProps = new NatsBinderConfigurationProperties();
             binderProps.setServer(ts.getURI());
@@ -283,12 +338,14 @@ class BinderTests {
                     new NatsExtendedBindingProperties());
             NatsChannelProvisioner provisioner = config.natsChannelProvisioner();
 
-            assertThat(config.natsBinder(provisioner)).isNull();
+            assertThatThrownBy(() -> config.natsBinder(provisioner))
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("NATS binder could not establish a connection");
         }
     }
 
     @Test
-    void createBinderReturnsNullWhenServerIsUnreachable() throws IOException, InterruptedException {
+    void createBinderFailsExplicitlyWhenServerIsUnreachable() {
         int unusedPort = NatsBinderTestServer.nextPort();
         NatsBinderConfigurationProperties binderProps = new NatsBinderConfigurationProperties();
         binderProps.setServer("nats://127.0.0.1:" + unusedPort);
@@ -301,7 +358,9 @@ class BinderTests {
                 new NatsExtendedBindingProperties());
         NatsChannelProvisioner provisioner = config.natsChannelProvisioner();
 
-        assertThat(config.natsBinder(provisioner)).isNull();
+        assertThatThrownBy(() -> config.natsBinder(provisioner))
+                .isInstanceOf(IOException.class)
+                .hasMessage("NATS binder could not establish a connection");
     }
 
     @Test
@@ -391,6 +450,17 @@ class BinderTests {
                 "nats.spring.cloud.stream.binder.server= ").run(context -> {
             assertThat(context).doesNotHaveBean(Connection.class);
             assertThat(context).doesNotHaveBean(NatsChannelBinder.class);
+        });
+    }
+
+    @Test
+    void springContextFailsExplicitlyWhenBinderServerIsUnreachable() {
+        int unusedPort = NatsBinderTestServer.nextPort();
+        this.binderContextRunner.withPropertyValues(
+                "nats.spring.cloud.stream.binder.server=nats://127.0.0.1:" + unusedPort,
+                "nats.spring.cloud.stream.binder.connectionTimeout=250ms").run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasRootCauseInstanceOf(IOException.class);
         });
     }
 
@@ -820,6 +890,46 @@ class BinderTests {
         MessageHandler handler = new NatsMessageHandler("handler.no.connection", null);
 
         assertThatCode(() -> handler.handleMessage(new GenericMessage<>("ignored"))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void messageHandlerRejectsNullSubject() {
+        assertThatThrownBy(() -> new NatsMessageHandler(null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("subject must not be null");
+    }
+
+    @Test
+    void messageProducerWithoutConnectionDoesNotStart() {
+        NatsMessageProducer producer = new NatsMessageProducer(new NatsConsumerDestination("producer.no.connection"), null);
+
+        assertThatCode(producer::start).doesNotThrowAnyException();
+        assertThat(producer.isRunning()).isFalse();
+        assertThatCode(producer::stop).doesNotThrowAnyException();
+    }
+
+    @Test
+    void messageProducerRejectsNullDestination() {
+        assertThatThrownBy(() -> new NatsMessageProducer(null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("destination must not be null");
+    }
+
+    @Test
+    void messageSourceWithoutConnectionDoesNotStartOrReceive() {
+        NatsMessageSource source = new NatsMessageSource(new NatsConsumerDestination("source.no.connection"), null);
+
+        assertThatCode(source::start).doesNotThrowAnyException();
+        assertThat(source.isRunning()).isFalse();
+        assertThat(source.receive()).isNull();
+        assertThatCode(source::stop).doesNotThrowAnyException();
+    }
+
+    @Test
+    void messageSourceRejectsNullDestination() {
+        assertThatThrownBy(() -> new NatsMessageSource(null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("destination must not be null");
     }
 
     @Test

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
@@ -377,6 +377,24 @@ class BinderTests {
     }
 
     @Test
+    void springContextDoesNotCreateBinderWithoutServerProperties() {
+        this.binderContextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(Connection.class);
+            assertThat(context).doesNotHaveBean(NatsChannelBinder.class);
+        });
+    }
+
+    @Test
+    void springContextDoesNotCreateBinderWithBlankServerProperties() {
+        this.binderContextRunner.withPropertyValues(
+                "nats.spring.server= ",
+                "nats.spring.cloud.stream.binder.server= ").run(context -> {
+            assertThat(context).doesNotHaveBean(Connection.class);
+            assertThat(context).doesNotHaveBean(NatsChannelBinder.class);
+        });
+    }
+
+    @Test
     void binderPropertiesWinOverGlobalProperties() throws IOException, InterruptedException {
         try (NatsBinderTestServer global = new NatsBinderTestServer();
              NatsBinderTestServer binderSpecific = new NatsBinderTestServer()) {

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/DestinationNameTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/DestinationNameTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DestinationNameTests {
@@ -35,6 +36,14 @@ public class DestinationNameTests {
 
         assertEquals(subject, dest.getName());
         assertEquals(subject + "-1", dest.getNameForPartition(1));
+    }
+
+    @Test
+    public void producerDestinationRejectsNullName() {
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> new NatsProducerDestination(null));
+
+        assertEquals("name must not be null", exception.getMessage());
     }
 
     @Test
@@ -56,6 +65,14 @@ public class DestinationNameTests {
 
         assertEquals(subject, dest.getSubject());
         assertEquals("", dest.getQueueGroup());
+    }
+
+    @Test
+    public void consumerDestinationRejectsNullName() {
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> new NatsConsumerDestination(null));
+
+        assertEquals("name must not be null", exception.getMessage());
     }
 
     @Test

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsAutoConfiguration.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsAutoConfiguration.java
@@ -49,7 +49,10 @@ public class NatsAutoConfiguration {
     private static final Log logger = LogFactory.getLog(NatsAutoConfiguration.class);
 
     /**
-     * @return NATS connection created with the provided properties. If no server URL is set the method will return null.
+     * @param properties         NATS connection properties, or {@code null} when called directly without bound properties
+     * @param connectionListener optional listener for connection state changes
+     * @param errorListener      optional listener for connection errors
+     * @return NATS connection created with the provided properties, or {@code null} when no server URL is configured
      * @throws IOException              when a connection error occurs
      * @throws InterruptedException     in the unusual case of a thread interruption during connect
      * @throws GeneralSecurityException if there is a problem authenticating the connection

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsAutoConfiguration.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -64,10 +65,9 @@ public class NatsAutoConfiguration {
     public Connection natsConnection(@Nullable NatsProperties properties, @Nullable ConnectionListener connectionListener,
                                      @Nullable ErrorListener errorListener)
             throws IOException, InterruptedException, GeneralSecurityException {
-        Connection nc = null;
-        String serverProp = (properties != null) ? properties.getServer() : null;
-
-        if (serverProp == null || serverProp.length() == 0) {
+        // Defensive for direct programmatic calls; bean creation is already gated by
+        // NatsServerConfiguredCondition when Spring creates this bean.
+        if (properties == null || !StringUtils.hasText(properties.getServer())) {
             return null;
         }
 
@@ -79,12 +79,11 @@ public class NatsAutoConfiguration {
 
             builder = builder.errorListener(errorListener);
 
-            nc = Nats.connect(builder.build());
+            return Nats.connect(builder.build());
         } catch (Exception e) {
             logger.info("error connecting to nats", e);
             throw e;
         }
-        return nc;
     }
 
     @Bean

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsAutoConfiguration.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsAutoConfiguration.java
@@ -30,6 +30,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.Nullable;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -54,7 +56,10 @@ public class NatsAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    public Connection natsConnection(NatsProperties properties, ConnectionListener connectionListener, ErrorListener errorListener)
+    @Conditional(NatsServerConfiguredCondition.class)
+    @Nullable
+    public Connection natsConnection(@Nullable NatsProperties properties, @Nullable ConnectionListener connectionListener,
+                                     @Nullable ErrorListener errorListener)
             throws IOException, InterruptedException, GeneralSecurityException {
         Connection nc = null;
         String serverProp = (properties != null) ? properties.getServer() : null;
@@ -83,7 +88,7 @@ public class NatsAutoConfiguration {
     @ConditionalOnMissingBean
     public ConnectionListener defaultConnectionListener() {
         return new ConnectionListener() {
-            public void connectionEvent(Connection conn, Events type) {
+            public void connectionEvent(@Nullable Connection conn, Events type) {
                 logger.info("NATS connection status changed " + type);
             }
         };
@@ -94,17 +99,17 @@ public class NatsAutoConfiguration {
     public ErrorListener defaultErrorListener() {
         return new ErrorListener() {
             @Override
-            public void slowConsumerDetected(Connection conn, Consumer consumer) {
+            public void slowConsumerDetected(@Nullable Connection conn, @Nullable Consumer consumer) {
                 logger.info("NATS connection slow consumer detected");
             }
 
             @Override
-            public void exceptionOccurred(Connection conn, Exception exp) {
+            public void exceptionOccurred(@Nullable Connection conn, Exception exp) {
                 logger.info("NATS connection exception occurred", exp);
             }
 
             @Override
-            public void errorOccurred(Connection conn, String error) {
+            public void errorOccurred(@Nullable Connection conn, String error) {
                 logger.info("NATS connection error occurred " + error);
             }
         };

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
@@ -19,6 +19,7 @@ package io.nats.spring.boot.autoconfigure;
 import io.nats.client.Nats;
 import io.nats.client.Options;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.lang.Nullable;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -212,6 +213,7 @@ public class NatsConnectionProperties {
     /**
      * @return url for the nats server
      */
+    @Nullable
     public String getServer() {
         return this.server;
     }
@@ -219,13 +221,14 @@ public class NatsConnectionProperties {
     /**
      * @param server url for the nats server
      */
-    public void setServer(String server) {
+    public void setServer(@Nullable String server) {
         this.server = server;
     }
 
     /**
      * @return a name used for the connection
      */
+    @Nullable
     public String getConnectionName() {
         return this.connectionName;
     }
@@ -233,7 +236,7 @@ public class NatsConnectionProperties {
     /**
      * @param connectionName a name to associate with the connection
      */
-    public void setConnectionName(String connectionName) {
+    public void setConnectionName(@Nullable String connectionName) {
         this.connectionName = connectionName;
     }
 
@@ -313,6 +316,7 @@ public class NatsConnectionProperties {
     /**
      * @return username to use with password for authenticaiton
      */
+    @Nullable
     public String getUsername() {
         return this.username;
     }
@@ -320,13 +324,14 @@ public class NatsConnectionProperties {
     /**
      * @param username to use with password for authenticaiton
      */
-    public void setUsername(String username) {
+    public void setUsername(@Nullable String username) {
         this.username = username;
     }
 
     /**
      * @return password to use with username for authenticaiton
      */
+    @Nullable
     public String getPassword() {
         return this.password;
     }
@@ -334,13 +339,14 @@ public class NatsConnectionProperties {
     /**
      * @param password to use with username for authenticaiton
      */
-    public void setPassword(String password) {
+    public void setPassword(@Nullable String password) {
         this.password = password;
     }
 
     /**
      * @return authentication token to use with the server
      */
+    @Nullable
     public String getToken() {
         return this.token;
     }
@@ -348,13 +354,14 @@ public class NatsConnectionProperties {
     /**
      * @param token authentication token to use with the server
      */
-    public void setToken(String token) {
+    public void setToken(@Nullable String token) {
         this.token = token;
     }
 
     /**
      * @return private key (seed) for NKey authentication with the server
      */
+    @Nullable
     public String getNkey() {
         return nkey;
     }
@@ -362,13 +369,14 @@ public class NatsConnectionProperties {
     /**
      * @param nkey private key (seed) for NKey authentication with the server
      */
-    public void setNkey(String nkey) {
+    public void setNkey(@Nullable String nkey) {
         this.nkey = nkey;
     }
 
     /**
      * @return user jwt for authentication with the server
      */
+    @Nullable
     public String getJwt() {
         return jwt;
     }
@@ -376,7 +384,7 @@ public class NatsConnectionProperties {
     /**
      * @param jwt user jwt for authentication with the server
      */
-    public void setJwt(String jwt) {
+    public void setJwt(@Nullable String jwt) {
         this.jwt = jwt;
     }
 
@@ -486,6 +494,7 @@ public class NatsConnectionProperties {
      * @return path to the credentials file to use for authentication with an
      * account enabled server
      */
+    @Nullable
     public String getCredentials() {
         return this.credentials;
     }
@@ -494,13 +503,14 @@ public class NatsConnectionProperties {
      * @param credentials path to the credentials file to use for authentication
      *                    with an account enabled server
      */
-    public void setCredentials(String credentials) {
+    public void setCredentials(@Nullable String credentials) {
         this.credentials = credentials;
     }
 
     /**
      * @return path to the SSL Keystore
      */
+    @Nullable
     public String getKeyStorePath() {
         return this.keyStorePath;
     }
@@ -508,13 +518,14 @@ public class NatsConnectionProperties {
     /**
      * @param keyStorePath file path for the SSL Keystore
      */
-    public void setKeyStorePath(String keyStorePath) {
+    public void setKeyStorePath(@Nullable String keyStorePath) {
         this.keyStorePath = keyStorePath;
     }
 
     /**
      * @return password used to unlock the keystore
      */
+    @Nullable
     public char[] getKeyStorePassword() {
         return this.keyStorePassword;
     }
@@ -522,13 +533,14 @@ public class NatsConnectionProperties {
     /**
      * @param keyStorePassword used to unlock the keystore
      */
-    public void setKeyStorePassword(char[] keyStorePassword) {
+    public void setKeyStorePassword(@Nullable char[] keyStorePassword) {
         this.keyStorePassword = keyStorePassword;
     }
 
     /**
      * @return type of keystore to use for SSL connections
      */
+    @Nullable
     public String getKeyStoreType() {
         return this.keyStoreType;
     }
@@ -537,13 +549,14 @@ public class NatsConnectionProperties {
      * @param keyStoreType generally the default, but available for special keystore
      *                     formats/types
      */
-    public void setKeyStoreType(String keyStoreType) {
+    public void setKeyStoreType(@Nullable String keyStoreType) {
         this.keyStoreType = keyStoreType;
     }
 
     /**
      * @return file path for the SSL trust store
      */
+    @Nullable
     public String getTrustStorePath() {
         return this.trustStorePath;
     }
@@ -551,13 +564,14 @@ public class NatsConnectionProperties {
     /**
      * @param trustStorePath file path for the SSL trust store
      */
-    public void setTrustStorePath(String trustStorePath) {
+    public void setTrustStorePath(@Nullable String trustStorePath) {
         this.trustStorePath = trustStorePath;
     }
 
     /**
      * @return password used to unlock the trust store
      */
+    @Nullable
     public char[] getTrustStorePassword() {
         return this.trustStorePassword;
     }
@@ -565,13 +579,14 @@ public class NatsConnectionProperties {
     /**
      * @param trustStorePassword used to unlock the trust store
      */
-    public void setTrustStorePassword(char[] trustStorePassword) {
+    public void setTrustStorePassword(@Nullable char[] trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
     }
 
     /**
      * @return type of keystore to use for SSL connections
      */
+    @Nullable
     public String getTrustStoreType() {
         return this.trustStoreType;
     }
@@ -580,13 +595,14 @@ public class NatsConnectionProperties {
      * @param trustStoreType generally the default, but available for special trust
      *                       store formats/types
      */
-    public void setTrustStoreType(String trustStoreType) {
+    public void setTrustStoreType(@Nullable String trustStoreType) {
         this.trustStoreType = trustStoreType;
     }
 
     /**
      * @return keyStoreProvider of keystore to use for SSL connections
      */
+    @Nullable
     public String getKeyStoreProvider() {
         return keyStoreProvider;
     }
@@ -594,13 +610,14 @@ public class NatsConnectionProperties {
     /**
      * @param keyStoreProvider defaults to SunX509. Alternatives include PKIX.
      */
-    public void setKeyStoreProvider(String keyStoreProvider) {
+    public void setKeyStoreProvider(@Nullable String keyStoreProvider) {
         this.keyStoreProvider = keyStoreProvider;
     }
 
     /**
      * @return trustStoreProvider of keystore to use for SSL connections
      */
+    @Nullable
     public String getTrustStoreProvider() {
         return trustStoreProvider;
     }
@@ -608,13 +625,14 @@ public class NatsConnectionProperties {
     /**
      * @param trustStoreProvider defaults to SunX509. Alternatives include PKIX.
      */
-    public void setTrustStoreProvider(String trustStoreProvider) {
+    public void setTrustStoreProvider(@Nullable String trustStoreProvider) {
         this.trustStoreProvider = trustStoreProvider;
     }
 
     /**
      * @return tlsProtocol to be used in TLS handshake
      */
+    @Nullable
     public String getTlsProtocol() {
         return tlsProtocol;
     }
@@ -622,7 +640,7 @@ public class NatsConnectionProperties {
     /**
      * @param tlsProtocol the tls protocol
      */
-    public void setTlsProtocol(String tlsProtocol) {
+    public void setTlsProtocol(@Nullable String tlsProtocol) {
         this.tlsProtocol = tlsProtocol;
     }
 
@@ -654,7 +672,7 @@ public class NatsConnectionProperties {
      *                  separated list
      * @return chainable properties
      */
-    public NatsConnectionProperties server(String serverURL) {
+    public NatsConnectionProperties server(@Nullable String serverURL) {
         this.server = serverURL;
         return this;
     }
@@ -663,7 +681,7 @@ public class NatsConnectionProperties {
      * @param connectionName used for the underlying nats connection
      * @return chainable properties
      */
-    public NatsConnectionProperties connectionName(String connectionName) {
+    public NatsConnectionProperties connectionName(@Nullable String connectionName) {
         this.connectionName = connectionName;
         return this;
     }
@@ -720,7 +738,7 @@ public class NatsConnectionProperties {
      * @param username for authentication
      * @return chainable properties
      */
-    public NatsConnectionProperties username(String username) {
+    public NatsConnectionProperties username(@Nullable String username) {
         this.username = username;
         return this;
     }
@@ -729,7 +747,7 @@ public class NatsConnectionProperties {
      * @param password for authentication
      * @return chainable properties
      */
-    public NatsConnectionProperties password(String password) {
+    public NatsConnectionProperties password(@Nullable String password) {
         this.password = password;
         return this;
     }
@@ -738,7 +756,7 @@ public class NatsConnectionProperties {
      * @param token for authentication
      * @return chainable properties
      */
-    public NatsConnectionProperties token(String token) {
+    public NatsConnectionProperties token(@Nullable String token) {
         this.token = token;
         return this;
     }
@@ -747,7 +765,7 @@ public class NatsConnectionProperties {
      * @param nkey private key (seed) for NKey authentication
      * @return chainable properties
      */
-    public NatsConnectionProperties nkey(String nkey) {
+    public NatsConnectionProperties nkey(@Nullable String nkey) {
         this.nkey = nkey;
         return this;
     }
@@ -756,7 +774,7 @@ public class NatsConnectionProperties {
      * @param jwt user jwt for authentication with the server
      * @return chainable properties
      */
-    public NatsConnectionProperties jwt(String jwt) {
+    public NatsConnectionProperties jwt(@Nullable String jwt) {
         this.jwt = jwt;
         return this;
     }
@@ -812,7 +830,7 @@ public class NatsConnectionProperties {
      *                    authentication
      * @return chainable properties
      */
-    public NatsConnectionProperties credentials(String credentials) {
+    public NatsConnectionProperties credentials(@Nullable String credentials) {
         this.credentials = credentials;
         return this;
     }
@@ -821,7 +839,7 @@ public class NatsConnectionProperties {
      * @param keyStorePath file path to SSL Key Store
      * @return chainable properties
      */
-    public NatsConnectionProperties keyStorePath(String keyStorePath) {
+    public NatsConnectionProperties keyStorePath(@Nullable String keyStorePath) {
         this.keyStorePath = keyStorePath;
         return this;
     }
@@ -830,7 +848,7 @@ public class NatsConnectionProperties {
      * @param keyStorePassword required to unlock the SSL Key Store
      * @return chainable properties
      */
-    public NatsConnectionProperties keyStorePassword(char[] keyStorePassword) {
+    public NatsConnectionProperties keyStorePassword(@Nullable char[] keyStorePassword) {
         this.keyStorePassword = keyStorePassword;
         return this;
     }
@@ -839,7 +857,7 @@ public class NatsConnectionProperties {
      * @param trustStorePath file path to SSL Trust Store
      * @return chainable properties
      */
-    public NatsConnectionProperties trustStorePath(String trustStorePath) {
+    public NatsConnectionProperties trustStorePath(@Nullable String trustStorePath) {
         this.trustStorePath = trustStorePath;
         return this;
     }
@@ -848,7 +866,7 @@ public class NatsConnectionProperties {
      * @param trustStorePassword required to unlock the SSL Trust Store
      * @return chainable properties
      */
-    public NatsConnectionProperties trustStorePassword(char[] trustStorePassword) {
+    public NatsConnectionProperties trustStorePassword(@Nullable char[] trustStorePassword) {
         setTrustStorePassword(trustStorePassword);
         return this;
     }
@@ -857,7 +875,7 @@ public class NatsConnectionProperties {
      * @param keyStoreType type/format of the SSL Key Store
      * @return chainable properties
      */
-    public NatsConnectionProperties keyStoreType(String keyStoreType) {
+    public NatsConnectionProperties keyStoreType(@Nullable String keyStoreType) {
         this.keyStoreType = keyStoreType;
         return this;
     }
@@ -866,7 +884,7 @@ public class NatsConnectionProperties {
      * @param keyStoreProvider of the SSL Key Store
      * @return chainable properties
      */
-    public NatsConnectionProperties keyStoreProvider(String keyStoreProvider) {
+    public NatsConnectionProperties keyStoreProvider(@Nullable String keyStoreProvider) {
         this.keyStoreProvider = keyStoreProvider;
         return this;
     }
@@ -875,7 +893,7 @@ public class NatsConnectionProperties {
      * @param trustStoreType type/format of the SSL Trust Store
      * @return chainable properties
      */
-    public NatsConnectionProperties trustStoreType(String trustStoreType) {
+    public NatsConnectionProperties trustStoreType(@Nullable String trustStoreType) {
         this.trustStoreType = trustStoreType;
         return this;
     }
@@ -884,7 +902,7 @@ public class NatsConnectionProperties {
      * @param trustStoreProvider of the SSL Trust Store
      * @return chainable properties
      */
-    public NatsConnectionProperties trustStoreProvider(String trustStoreProvider) {
+    public NatsConnectionProperties trustStoreProvider(@Nullable String trustStoreProvider) {
         this.trustStoreProvider = trustStoreProvider;
         return this;
     }
@@ -893,7 +911,7 @@ public class NatsConnectionProperties {
      * @param tlsProtocol the tls protocol
      * @return chainable properties
      */
-    public NatsConnectionProperties tlsProtocol(String tlsProtocol) {
+    public NatsConnectionProperties tlsProtocol(@Nullable String tlsProtocol) {
         this.tlsProtocol = tlsProtocol;
         return this;
     }

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsConnectionProperties.java
@@ -33,6 +33,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Objects;
 
 /**
  * Nats Connection Properties.
@@ -57,7 +58,7 @@ public class NatsConnectionProperties {
      */
     private final String defaultTrustStoreProviderAlgorithm = "SunX509";
     /**
-     * URL for the nats server, can be a comma separated list.
+     * URL for the NATS server, can be a comma separated list.
      */
     private String server;
     /**
@@ -211,7 +212,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @return url for the nats server
+     * @return URL for the NATS server, or {@code null} when no server was configured
      */
     @Nullable
     public String getServer() {
@@ -219,14 +220,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param server url for the nats server
+     * @param server URL for the NATS server, or {@code null} to leave the connection unconfigured
      */
     public void setServer(@Nullable String server) {
         this.server = server;
     }
 
     /**
-     * @return a name used for the connection
+     * @return name used for the connection, or {@code null} when no name was configured
      */
     @Nullable
     public String getConnectionName() {
@@ -234,7 +235,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param connectionName a name to associate with the connection
+     * @param connectionName name to associate with the connection, or {@code null} to use the client default
      */
     public void setConnectionName(@Nullable String connectionName) {
         this.connectionName = connectionName;
@@ -262,11 +263,11 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param reconnectWait time to wait between reconnect attempts on the same
-     *                      server url
+     * @param reconnectWait time to wait between reconnect attempts on the same server URL; must not be {@code null}
+     * @throws NullPointerException if {@code reconnectWait} is {@code null}
      */
     public void setReconnectWait(Duration reconnectWait) {
-        this.reconnectWait = reconnectWait;
+        this.reconnectWait = Objects.requireNonNull(reconnectWait, "reconnectWait must not be null");
     }
 
     /**
@@ -277,10 +278,11 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param connectionTimeout maximum time for initial connection
+     * @param connectionTimeout maximum time for initial connection; must not be {@code null}
+     * @throws NullPointerException if {@code connectionTimeout} is {@code null}
      */
     public void setConnectionTimeout(Duration connectionTimeout) {
-        this.connectionTimeout = connectionTimeout;
+        this.connectionTimeout = Objects.requireNonNull(connectionTimeout, "connectionTimeout must not be null");
     }
 
     /**
@@ -291,10 +293,11 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param pingInterval time between server pings
+     * @param pingInterval time between server pings; must not be {@code null}
+     * @throws NullPointerException if {@code pingInterval} is {@code null}
      */
     public void setPingInterval(Duration pingInterval) {
-        this.pingInterval = pingInterval;
+        this.pingInterval = Objects.requireNonNull(pingInterval, "pingInterval must not be null");
     }
 
     /**
@@ -314,7 +317,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @return username to use with password for authenticaiton
+     * @return username to use with password authentication, or {@code null} when username authentication is not configured
      */
     @Nullable
     public String getUsername() {
@@ -322,14 +325,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param username to use with password for authenticaiton
+     * @param username username to use with password authentication, or {@code null} to disable username authentication
      */
     public void setUsername(@Nullable String username) {
         this.username = username;
     }
 
     /**
-     * @return password to use with username for authenticaiton
+     * @return password to use with username authentication, or {@code null} when no password was configured
      */
     @Nullable
     public String getPassword() {
@@ -337,14 +340,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param password to use with username for authenticaiton
+     * @param password password to use with username authentication, or {@code null} to leave it unset
      */
     public void setPassword(@Nullable String password) {
         this.password = password;
     }
 
     /**
-     * @return authentication token to use with the server
+     * @return authentication token to use with the server, or {@code null} when token authentication is not configured
      */
     @Nullable
     public String getToken() {
@@ -352,14 +355,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param token authentication token to use with the server
+     * @param token authentication token to use with the server, or {@code null} to disable token authentication
      */
     public void setToken(@Nullable String token) {
         this.token = token;
     }
 
     /**
-     * @return private key (seed) for NKey authentication with the server
+     * @return private key seed for NKey authentication with the server, or {@code null} when NKey authentication is not configured
      */
     @Nullable
     public String getNkey() {
@@ -367,14 +370,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param nkey private key (seed) for NKey authentication with the server
+     * @param nkey private key seed for NKey authentication with the server, or {@code null} to disable NKey authentication
      */
     public void setNkey(@Nullable String nkey) {
         this.nkey = nkey;
     }
 
     /**
-     * @return user jwt for authentication with the server
+     * @return user JWT for authentication with the server, or {@code null} when no JWT was configured
      */
     @Nullable
     public String getJwt() {
@@ -382,7 +385,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param jwt user jwt for authentication with the server
+     * @param jwt user JWT for authentication with the server, or {@code null} to leave it unset
      */
     public void setJwt(@Nullable String jwt) {
         this.jwt = jwt;
@@ -396,10 +399,11 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param inboxPrefix custom prefix to use for request/reply inboxes
+     * @param inboxPrefix custom prefix to use for request/reply inboxes; must not be {@code null}
+     * @throws NullPointerException if {@code inboxPrefix} is {@code null}
      */
     public void setInboxPrefix(String inboxPrefix) {
-        this.inboxPrefix = inboxPrefix;
+        this.inboxPrefix = Objects.requireNonNull(inboxPrefix, "inboxPrefix must not be null");
     }
 
     /**
@@ -491,8 +495,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @return path to the credentials file to use for authentication with an
-     * account enabled server
+     * @return path to the credentials file to use for authentication, or {@code null} when credentials-file authentication is not configured
      */
     @Nullable
     public String getCredentials() {
@@ -500,15 +503,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param credentials path to the credentials file to use for authentication
-     *                    with an account enabled server
+     * @param credentials path to the credentials file to use for authentication, or {@code null} to disable credentials-file authentication
      */
     public void setCredentials(@Nullable String credentials) {
         this.credentials = credentials;
     }
 
     /**
-     * @return path to the SSL Keystore
+     * @return path to the SSL keystore, or {@code null} when TLS keystore configuration is absent
      */
     @Nullable
     public String getKeyStorePath() {
@@ -516,14 +518,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStorePath file path for the SSL Keystore
+     * @param keyStorePath file path for the SSL keystore, or {@code null} to leave it unset
      */
     public void setKeyStorePath(@Nullable String keyStorePath) {
         this.keyStorePath = keyStorePath;
     }
 
     /**
-     * @return password used to unlock the keystore
+     * @return password used to unlock the keystore, or {@code null} to use an empty password when the keystore is loaded
      */
     @Nullable
     public char[] getKeyStorePassword() {
@@ -531,14 +533,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStorePassword used to unlock the keystore
+     * @param keyStorePassword password used to unlock the keystore, or {@code null} to use an empty password when the keystore is loaded
      */
     public void setKeyStorePassword(@Nullable char[] keyStorePassword) {
         this.keyStorePassword = keyStorePassword;
     }
 
     /**
-     * @return type of keystore to use for SSL connections
+     * @return type of keystore to use for SSL connections, or {@code null} to use the default type
      */
     @Nullable
     public String getKeyStoreType() {
@@ -546,15 +548,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStoreType generally the default, but available for special keystore
-     *                     formats/types
+     * @param keyStoreType keystore type to use for SSL connections, or {@code null} to use the default type
      */
     public void setKeyStoreType(@Nullable String keyStoreType) {
         this.keyStoreType = keyStoreType;
     }
 
     /**
-     * @return file path for the SSL trust store
+     * @return file path for the SSL trust store, or {@code null} when TLS trust store configuration is absent
      */
     @Nullable
     public String getTrustStorePath() {
@@ -562,14 +563,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStorePath file path for the SSL trust store
+     * @param trustStorePath file path for the SSL trust store, or {@code null} to leave it unset
      */
     public void setTrustStorePath(@Nullable String trustStorePath) {
         this.trustStorePath = trustStorePath;
     }
 
     /**
-     * @return password used to unlock the trust store
+     * @return password used to unlock the trust store, or {@code null} to use an empty password when the trust store is loaded
      */
     @Nullable
     public char[] getTrustStorePassword() {
@@ -577,14 +578,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStorePassword used to unlock the trust store
+     * @param trustStorePassword password used to unlock the trust store, or {@code null} to use an empty password when the trust store is loaded
      */
     public void setTrustStorePassword(@Nullable char[] trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
     }
 
     /**
-     * @return type of keystore to use for SSL connections
+     * @return type of trust store to use for SSL connections, or {@code null} to use the default type
      */
     @Nullable
     public String getTrustStoreType() {
@@ -592,15 +593,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStoreType generally the default, but available for special trust
-     *                       store formats/types
+     * @param trustStoreType trust store type to use for SSL connections, or {@code null} to use the default type
      */
     public void setTrustStoreType(@Nullable String trustStoreType) {
         this.trustStoreType = trustStoreType;
     }
 
     /**
-     * @return keyStoreProvider of keystore to use for SSL connections
+     * @return keystore provider algorithm to use for SSL connections, or {@code null} to use the default provider
      */
     @Nullable
     public String getKeyStoreProvider() {
@@ -608,14 +608,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStoreProvider defaults to SunX509. Alternatives include PKIX.
+     * @param keyStoreProvider keystore provider algorithm to use for SSL connections, or {@code null} to use the default provider
      */
     public void setKeyStoreProvider(@Nullable String keyStoreProvider) {
         this.keyStoreProvider = keyStoreProvider;
     }
 
     /**
-     * @return trustStoreProvider of keystore to use for SSL connections
+     * @return trust store provider algorithm to use for SSL connections, or {@code null} to use the default provider
      */
     @Nullable
     public String getTrustStoreProvider() {
@@ -623,14 +623,14 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStoreProvider defaults to SunX509. Alternatives include PKIX.
+     * @param trustStoreProvider trust store provider algorithm to use for SSL connections, or {@code null} to use the default provider
      */
     public void setTrustStoreProvider(@Nullable String trustStoreProvider) {
         this.trustStoreProvider = trustStoreProvider;
     }
 
     /**
-     * @return tlsProtocol to be used in TLS handshake
+     * @return TLS protocol to use in the TLS handshake, or {@code null} to use the client default
      */
     @Nullable
     public String getTlsProtocol() {
@@ -638,7 +638,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param tlsProtocol the tls protocol
+     * @param tlsProtocol TLS protocol to use in the TLS handshake, or {@code null} to use the client default
      */
     public void setTlsProtocol(@Nullable String tlsProtocol) {
         this.tlsProtocol = tlsProtocol;
@@ -668,8 +668,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param serverURL used for the underlying nats connection, can be a comma
-     *                  separated list
+     * @param serverURL used for the underlying NATS connection, can be a comma separated list, or {@code null} to leave the connection unconfigured
      * @return chainable properties
      */
     public NatsConnectionProperties server(@Nullable String serverURL) {
@@ -678,7 +677,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param connectionName used for the underlying nats connection
+     * @param connectionName used for the underlying NATS connection, or {@code null} to use the client default
      * @return chainable properties
      */
     public NatsConnectionProperties connectionName(@Nullable String connectionName) {
@@ -697,30 +696,32 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param reconnectWait time to wait between reconnect attempts to the same
-     *                      server url
+     * @param reconnectWait time to wait between reconnect attempts to the same server URL; must not be {@code null}
      * @return chainable properties
+     * @throws NullPointerException if {@code reconnectWait} is {@code null}
      */
     public NatsConnectionProperties reconnectWait(Duration reconnectWait) {
-        this.reconnectWait = reconnectWait;
+        this.reconnectWait = Objects.requireNonNull(reconnectWait, "reconnectWait must not be null");
         return this;
     }
 
     /**
-     * @param connectionTimeout maximum time to allow the initial connection to take
+     * @param connectionTimeout maximum time to allow the initial connection to take; must not be {@code null}
      * @return chainable properties
+     * @throws NullPointerException if {@code connectionTimeout} is {@code null}
      */
     public NatsConnectionProperties connectionTimeout(Duration connectionTimeout) {
-        this.connectionTimeout = connectionTimeout;
+        this.connectionTimeout = Objects.requireNonNull(connectionTimeout, "connectionTimeout must not be null");
         return this;
     }
 
     /**
-     * @param pingInterval time between heartbeat pings to the server
+     * @param pingInterval time between heartbeat pings to the server; must not be {@code null}
      * @return chainable properties
+     * @throws NullPointerException if {@code pingInterval} is {@code null}
      */
     public NatsConnectionProperties pingInterval(Duration pingInterval) {
-        this.pingInterval = pingInterval;
+        this.pingInterval = Objects.requireNonNull(pingInterval, "pingInterval must not be null");
         return this;
     }
 
@@ -735,7 +736,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param username for authentication
+     * @param username username for authentication, or {@code null} to disable username authentication
      * @return chainable properties
      */
     public NatsConnectionProperties username(@Nullable String username) {
@@ -744,7 +745,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param password for authentication
+     * @param password password for authentication, or {@code null} to leave it unset
      * @return chainable properties
      */
     public NatsConnectionProperties password(@Nullable String password) {
@@ -753,7 +754,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param token for authentication
+     * @param token token for authentication, or {@code null} to disable token authentication
      * @return chainable properties
      */
     public NatsConnectionProperties token(@Nullable String token) {
@@ -762,7 +763,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param nkey private key (seed) for NKey authentication
+     * @param nkey private key seed for NKey authentication, or {@code null} to disable NKey authentication
      * @return chainable properties
      */
     public NatsConnectionProperties nkey(@Nullable String nkey) {
@@ -771,7 +772,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param jwt user jwt for authentication with the server
+     * @param jwt user JWT for authentication with the server, or {@code null} to leave it unset
      * @return chainable properties
      */
     public NatsConnectionProperties jwt(@Nullable String jwt) {
@@ -780,11 +781,12 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param inboxPrefix custom prefix to use for request/reply inboxes
+     * @param inboxPrefix custom prefix to use for request/reply inboxes; must not be {@code null}
      * @return chainable properties
+     * @throws NullPointerException if {@code inboxPrefix} is {@code null}
      */
     public NatsConnectionProperties inboxPrefix(String inboxPrefix) {
-        this.inboxPrefix = inboxPrefix;
+        this.inboxPrefix = Objects.requireNonNull(inboxPrefix, "inboxPrefix must not be null");
         return this;
     }
 
@@ -826,8 +828,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param credentials file path to the user credentials to use for
-     *                    authentication
+     * @param credentials file path to the user credentials to use for authentication, or {@code null} to disable credentials-file authentication
      * @return chainable properties
      */
     public NatsConnectionProperties credentials(@Nullable String credentials) {
@@ -836,7 +837,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStorePath file path to SSL Key Store
+     * @param keyStorePath file path to SSL keystore, or {@code null} to leave it unset
      * @return chainable properties
      */
     public NatsConnectionProperties keyStorePath(@Nullable String keyStorePath) {
@@ -845,7 +846,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStorePassword required to unlock the SSL Key Store
+     * @param keyStorePassword password required to unlock the SSL keystore, or {@code null} to use an empty password when the keystore is loaded
      * @return chainable properties
      */
     public NatsConnectionProperties keyStorePassword(@Nullable char[] keyStorePassword) {
@@ -854,7 +855,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStorePath file path to SSL Trust Store
+     * @param trustStorePath file path to SSL trust store, or {@code null} to leave it unset
      * @return chainable properties
      */
     public NatsConnectionProperties trustStorePath(@Nullable String trustStorePath) {
@@ -863,7 +864,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStorePassword required to unlock the SSL Trust Store
+     * @param trustStorePassword password required to unlock the SSL trust store, or {@code null} to use an empty password when the trust store is loaded
      * @return chainable properties
      */
     public NatsConnectionProperties trustStorePassword(@Nullable char[] trustStorePassword) {
@@ -872,7 +873,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStoreType type/format of the SSL Key Store
+     * @param keyStoreType type/format of the SSL keystore, or {@code null} to use the default type
      * @return chainable properties
      */
     public NatsConnectionProperties keyStoreType(@Nullable String keyStoreType) {
@@ -881,7 +882,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param keyStoreProvider of the SSL Key Store
+     * @param keyStoreProvider provider algorithm of the SSL keystore, or {@code null} to use the default provider
      * @return chainable properties
      */
     public NatsConnectionProperties keyStoreProvider(@Nullable String keyStoreProvider) {
@@ -890,7 +891,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStoreType type/format of the SSL Trust Store
+     * @param trustStoreType type/format of the SSL trust store, or {@code null} to use the default type
      * @return chainable properties
      */
     public NatsConnectionProperties trustStoreType(@Nullable String trustStoreType) {
@@ -899,7 +900,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param trustStoreProvider of the SSL Trust Store
+     * @param trustStoreProvider provider algorithm of the SSL trust store, or {@code null} to use the default provider
      * @return chainable properties
      */
     public NatsConnectionProperties trustStoreProvider(@Nullable String trustStoreProvider) {
@@ -908,7 +909,7 @@ public class NatsConnectionProperties {
     }
 
     /**
-     * @param tlsProtocol the tls protocol
+     * @param tlsProtocol TLS protocol to use in the TLS handshake, or {@code null} to use the client default
      * @return chainable properties
      */
     public NatsConnectionProperties tlsProtocol(@Nullable String tlsProtocol) {

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsProperties.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * NatsProperties extends NatsConnectionProperties, which provides all of the
  * attributes, setters and getters. A NatsProperties configuration is used
- * during autoconfigure to initialize the underlying NATs connection.
+ * during autoconfigure to initialize the underlying NATS connection.
  */
 @ConditionalOnClass({Options.class})
 @ConfigurationProperties(prefix = "nats.spring")

--- a/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsServerConfiguredCondition.java
+++ b/nats-spring/src/main/java/io/nats/spring/boot/autoconfigure/NatsServerConfiguredCondition.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nats.spring.boot.autoconfigure;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+class NatsServerConfiguredCondition implements Condition {
+    static final String SERVER_PROPERTY = "nats.spring.server";
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return StringUtils.hasText(context.getEnvironment().getProperty(SERVER_PROPERTY));
+    }
+}

--- a/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/AutoconfigureTests.java
+++ b/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/AutoconfigureTests.java
@@ -81,6 +81,17 @@ class AutoconfigureTests {
     }
 
     @Test
+    void springContextDoesNotCreateConnectionWithoutServerProperties() {
+        this.contextRunner.run(context -> assertThat(context).doesNotHaveBean(Connection.class));
+    }
+
+    @Test
+    void springContextDoesNotCreateConnectionWithBlankServerProperty() {
+        this.contextRunner.withPropertyValues("nats.spring.server= ").run(context ->
+                assertThat(context).doesNotHaveBean(Connection.class));
+    }
+
+    @Test
     void directConnectionFactoryUsesProgrammaticProperties() throws Exception {
         try (NatsTestServer ts = new NatsTestServer()) {
             NatsProperties properties = new NatsProperties();

--- a/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/PropertiesTests.java
+++ b/nats-spring/src/test/java/io/nats/spring/boot/autoconfigure/PropertiesTests.java
@@ -129,6 +129,42 @@ public class PropertiesTests {
     }
 
     @Test
+    public void requiredSetterValuesRejectNull() {
+        NatsConnectionProperties props = new NatsConnectionProperties();
+
+        assertThatThrownBy(() -> props.setReconnectWait(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("reconnectWait must not be null");
+        assertThatThrownBy(() -> props.setConnectionTimeout(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("connectionTimeout must not be null");
+        assertThatThrownBy(() -> props.setPingInterval(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("pingInterval must not be null");
+        assertThatThrownBy(() -> props.setInboxPrefix(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("inboxPrefix must not be null");
+    }
+
+    @Test
+    public void requiredFluentValuesRejectNull() {
+        NatsConnectionProperties props = new NatsConnectionProperties();
+
+        assertThatThrownBy(() -> props.reconnectWait(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("reconnectWait must not be null");
+        assertThatThrownBy(() -> props.connectionTimeout(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("connectionTimeout must not be null");
+        assertThatThrownBy(() -> props.pingInterval(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("pingInterval must not be null");
+        assertThatThrownBy(() -> props.inboxPrefix(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("inboxPrefix must not be null");
+    }
+
+    @Test
     public void testCommaListOfServers() throws Exception {
         String server1 = "nats://alphabet:4222";
         String server2 = "nats://tebahpla:4222";


### PR DESCRIPTION
## Summary

- Mark existing nullable configuration and binder contracts with Spring `@Nullable` annotations already available on the classpath.
- Avoid creating Spring null-beans when core or binder server properties are missing or blank.
- Add explicit no-dependency null-contract cleanup where it was safe to do now: Javadocs for nullable public contracts, public boundary null guards, and regression tests for null/no-connection behavior.
- Add Spring-context tests for missing and blank server configuration while keeping existing real NATS coverage intact.

## Issue

Related to #62. This improves the current null contracts without adding a JSpecify dependency or changing the broader null-safety strategy.

It also intentionally includes the small no-new-library slice that was possible right now from the broader discussion around #75 and #78: making behavior more explicit, more inspectable, and better covered without introducing new analysis or codegen dependencies.

This PR does not attempt to solve #74 or implement full Error Prone, JSpecify, or Lombok adoption.

## Verification

- `./mvnw -pl nats-spring,nats-spring-cloud-stream-binder -Dtest=AutoconfigureTests,BinderTests,PropertiesTests,DestinationNameTests test`
- `./mvnw test`
- `./mvnw -pl nats-spring,nats-spring-cloud-stream-binder -DskipTests javadoc:javadoc`
- `git diff --check`
- `nats-spring` JaCoCo: 100.00% instruction coverage, 94.59% branch coverage
- `nats-spring-cloud-stream-binder` JaCoCo: 96.65% instruction coverage, 91.16% branch coverage
