### PR TITLE
Upgrade to Spring Boot 4.0.7

### DIFF
--- a/nats-spring-boot-starter/pom.xml
+++ b/nats-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>nats-spring-boot-starter</artifactId>
     <description>NATS Starter for Spring</description>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <organization>
@@ -16,7 +16,7 @@
     <parent>
         <groupId>io.nats</groupId>
         <artifactId>nats-spring-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>nats-spring</artifactId>
-            <version>0.6.3+3.5-SNAPSHOT</version>
+            <version>0.7.0+4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/nats-spring-cloud-stream-binder/pom.xml
+++ b/nats-spring-cloud-stream-binder/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>nats-spring-cloud-stream-binder</artifactId>
     <description>Spring Cloud Stream Binder for NATS</description>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <organization>
         <name>CNCF</name>
         <url>https://www.nats.io</url>
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.nats</groupId>
         <artifactId>nats-spring-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>nats-spring</artifactId>
-            <version>0.6.3+3.5-SNAPSHOT</version>
+            <version>0.7.0+4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
+++ b/nats-spring-cloud-stream-binder/src/main/java/io/nats/cloud/stream/binder/NatsChannelBinder.java
@@ -153,8 +153,10 @@ public class NatsChannelBinder extends
                                                           ExtendedProducerProperties<NatsProducerProperties> producerProperties, MessageChannel errorChannel) {
         NatsProducerProperties extension = producerExtension(producerProperties);
         NatsJetStreamSupport.provisionStream(this.connection, destination.getName(), extension);
-        return new NatsMessageHandler(destination.getName(), this.connection, shouldUseNativeHeaders(producerProperties),
+        NatsMessageHandler natsMessageHandler = new NatsMessageHandler(destination.getName(), this.connection, shouldUseNativeHeaders(producerProperties),
                 isJetStream(extension), streamName(extension));
+        natsMessageHandler.setBeanFactory(getBeanFactory());
+        return natsMessageHandler;
     }
 
     @Override

--- a/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
+++ b/nats-spring-cloud-stream-binder/src/test/java/io/nats/cloud/stream/binder/BinderTests.java
@@ -812,6 +812,7 @@ class BinderTests {
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext());
                     String theMessage = "hello world";
                     String out = "out";
                     ProducerDestination to = fixture.provisioner().provisionProducerDestination(out, null);
@@ -849,6 +850,7 @@ class BinderTests {
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext());
                     String subject = "handler.headers.issue65";
                     String payload = "headers survive publish";
                     ProducerDestination to = fixture.provisioner().provisionProducerDestination(subject, null);
@@ -888,6 +890,7 @@ class BinderTests {
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext());
                     String subject = "handler.headers.skipped";
                     String payload = "only payload";
                     ProducerDestination to = fixture.provisioner().provisionProducerDestination(subject, null);
@@ -2342,6 +2345,7 @@ class BinderTests {
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext());
                     String stream = uniqueNatsName("JS_REPLY");
                     String subject = uniqueSubject("jetstream.reply.issue52");
                     addMemoryStream(conn, stream, subject);
@@ -2371,6 +2375,7 @@ class BinderTests {
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext());
                     String stream = uniqueNatsName("JS_MISSING_PUBLISH");
                     String subject = uniqueSubject("jetstream.missing.publish.issue52");
                     ExtendedProducerProperties<NatsProducerProperties> producerProperties =
@@ -2714,6 +2719,7 @@ class BinderTests {
                 assertConnected(conn, ts.getURI());
 
                 try (BinderFixture fixture = newGlobalBinder(ts.getURI())) {
+                    fixture.binder().setApplicationContext(context.getSourceApplicationContext());
                     String request = "hello request";
                     String reply = "hello reply";
                     String req2rep = "req2rep";
@@ -2902,6 +2908,7 @@ class BinderTests {
                                            NatsBinderConfigurationProperties binderProperties)
             throws IOException, InterruptedException {
         NatsExtendedBindingProperties props = new NatsExtendedBindingProperties();
+        props.setApplicationContext(new GenericApplicationContext());
         NatsChannelBinderConfiguration config = new NatsChannelBinderConfiguration(
                 null,
                 null,

--- a/nats-spring-samples/autoconfigure-sample/pom.xml
+++ b/nats-spring-samples/autoconfigure-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-autoconfigure</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>autoconfigure-sample</name>
     <description>A spring boot app that uses the autoconfigure NATS connection</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>nats-spring</artifactId>
-            <version>0.6.3+3.5-SNAPSHOT</version>
+            <version>0.7.0+4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nats-spring-samples/connect-error-sample/pom.xml
+++ b/nats-spring-samples/connect-error-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-connect-error</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>connect-error-sample</name>
     <description>A sample that sets up a custom connection and error listener for the NATS binder</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/listener-sample/pom.xml
+++ b/nats-spring-samples/listener-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-listener</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>listener-sample</name>
     <description>A listener using the nats binder</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/multi-connect-sample/pom.xml
+++ b/nats-spring-samples/multi-connect-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-multi-connect</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>multi-connect-sample</name>
     <description>A simple sample for the nats cloud stream binder</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/polling-sample/pom.xml
+++ b/nats-spring-samples/polling-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-polling</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>polling-sample</name>
     <description>A poller using the nats binder</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/pom.xml
+++ b/nats-spring-samples/pom.xml
@@ -5,13 +5,13 @@
 
     <groupId>io.nats.nats-spring-samples</groupId>
     <artifactId>nats-spring-samples-parent</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>io.nats</groupId>
         <artifactId>nats-spring-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/processor-sample/pom.xml
+++ b/nats-spring-samples/processor-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-processor</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>processor-sample</name>
     <description>A simple sample for the nats cloud stream binding with a processor</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/queue-sample/pom.xml
+++ b/nats-spring-samples/queue-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-queue</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>queue-sample</name>
     <description>A queue listener using the nats binder</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring-samples/source-sample/pom.xml
+++ b/nats-spring-samples/source-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nats-spring-samples-source</artifactId>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>source-sample</name>
     <description>A source using the nats binder</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.nats.nats-spring-samples</groupId>
         <artifactId>nats-spring-samples-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nats-spring/pom.xml
+++ b/nats-spring/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>nats-spring</artifactId>
     <description>NATS Implementation for Spring</description>
-    <version>0.6.3+3.5-SNAPSHOT</version>
+    <version>0.7.0+4.0-SNAPSHOT</version>
     <organization>
         <name>CNCF</name>
         <url>https://www.nats.io</url>
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.nats</groupId>
         <artifactId>nats-spring-parent</artifactId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,19 +5,19 @@
 
     <artifactId>nats-spring-parent</artifactId>
     <groupId>io.nats</groupId>
-        <version>0.6.3+3.5-SNAPSHOT</version>
+        <version>0.7.0+4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>3.1.8</version>
+        <version>5.0.2</version>
         <relativePath/>
     </parent>
 
     <properties>
-        <spring-boot.version>3.5.14</spring-boot.version>
-        <spring-cloud-stream.version>4.2.1</spring-cloud-stream.version>
+        <spring-boot.version>4.0.7</spring-boot.version>
+        <spring-cloud-stream.version>5.0.2</spring-cloud-stream.version>
         <java.version>17</java.version>
         <jacoco.version>0.8.13</jacoco.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>


### PR DESCRIPTION
- Upgraded Spring Boot version to 4.0.7 in all relevant pom.xml files.
- Updated dependencies to be compatible with Spring Boot 4.0.7.
- Adjusted code in NatsChannelBinder.java and BinderTests.java to accommodate any breaking changes or new features introduced in Spring Boot 4.0.7.

Closes gh-63